### PR TITLE
* [jsfm] fix undefined for element's depth

### DIFF
--- a/src/js-framework/lib/vm/compiler.js
+++ b/src/js-framework/lib/vm/compiler.js
@@ -350,7 +350,7 @@ export function _checkDisplay(target, fragBlock, context) {
 export function _watchBlock(fragBlock, calc, type, handler) {
   const differ = this && this._app && this._app.differ
   const config = {}
-  const depth = fragBlock.element.depth + 1
+  const depth = (fragBlock.element.depth || 0) + 1
 
   this._watch(calc, (value) => {
     config.latestValue = value

--- a/src/js-framework/package.json
+++ b/src/js-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weex-jsframework",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "JS Framework for Weex solution which is a extendable cross-platform solution for dynamic programming and publishing projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
for a example

```
<template>
  <container append="tree">
    <text repeat="{{list}}">{{text}}</text>
  </container>
</template>

<script>
module.exports = {
  data: {
    list: []
  },
  created: function() {
    someAsyncMethod(function() {
       this.list.push({text: 123})
    })
  }
}
</script>
```

will cause `undefined` for `fragBlock.element.depth` when calling `_watchBlock` in `lib/vm/compiler.js`.

so, just set 0 by default to fix it.
