### PR TITLE
+ [jsfm] supported inline event binding format

### DIFF
--- a/src/js-framework/lib/vm/__test__/directive.js
+++ b/src/js-framework/lib/vm/__test__/directive.js
@@ -293,8 +293,22 @@ describe('bind events', () => {
     manager = null
   })
   // - bind method to eventManager
-  it('add event to manager', () => {
+  it('add event to manager by type', () => {
     vm._bindEvents(el, {click: 'foo'})
+    expect(manager.targets.length).equal(1)
+    var target = manager.targets[0]
+    expect(target).a('object')
+    expect(target.el).equal(el)
+    expect(target.events).a('object')
+    expect(target.events.click).a('function')
+    expect(el.event.length).equal(1)
+    expect(el.event[0]).equal('click')
+  })
+  // - bind method to eventManager
+  it('add event to manager by handler', () => {
+    vm._bindEvents(el, {click: function ($event) {
+      this.foo(this.a, $event)
+    }})
     expect(manager.targets.length).equal(1)
     var target = manager.targets[0]
     expect(target).a('object')
@@ -306,13 +320,25 @@ describe('bind events', () => {
   })
   // - fireEvent to call method
   // - with right event info
-  it('fire event from manager', () => {
+  it('fire event from manager by type', () => {
     var e = {}
     vm._bindEvents(el, {click: 'foo'})
     manager.fire(el, 'click', e)
     expect(cb).calledOnce
     expect(cb).calledOn(vm)
     expect(cb).calledWith(e)
+  })
+  // - fireEvent to call method
+  // - with right event info
+  it('fire event from manager by handler', () => {
+    var e = {}
+    vm._bindEvents(el, {click: function ($event) {
+      this.foo(this.a, $event)
+    }})
+    manager.fire(el, 'click', e)
+    expect(cb).calledOnce
+    expect(cb).calledOn(vm)
+    expect(cb).calledWith(1, e)
   })
 })
 

--- a/src/js-framework/lib/vm/directive.js
+++ b/src/js-framework/lib/vm/directive.js
@@ -220,8 +220,11 @@ export function _bindEvents(el, events) {
   let i = keys.length
   while (i--) {
     const key = keys[i]
-    const handlerName = events[key]
-    this._setEvent(el, key, this[handlerName])
+    let handler = events[key]
+    if (typeof handler === 'string') {
+      handler = this[handler]
+    }
+    this._setEvent(el, key, handler)
   }
 }
 


### PR DESCRIPTION
supported both old and new version bundle format for event binding:

``` javascript
{
  type: 'foo',
  events: {
    'click': 'methodA', // old version: onclick="methodA"
    'appear': function ($event) { // new version: onappear="methodA(x, 1, '2', $event)"
      this.methodA(this.x, 1, '2', $event)
    }
  }
}
```
