### PR TITLE
* [html5] fix getconfig fields, add osName field

### DIFF
--- a/src/h5-render/src/config.js
+++ b/src/h5-render/src/config.js
@@ -2,7 +2,7 @@
 
 var config = {
 
-  weexVersion: '1.4.0',
+  weexVersion: '0.5.0',
 
   debug: true
 

--- a/src/h5-render/src/weex.js
+++ b/src/h5-render/src/weex.js
@@ -19,18 +19,18 @@ require('envd')
 var WEAPP_STYLE_ID = 'weapp-style'
 
 var DEFAULT_DESIGN_WIDTH = 750
+var DEFAULT_SCALE = window.innerWidth / DEFAULT_DESIGN_WIDTH
 var DEFAULT_ROOT_ID = 'weex'
 var DEFAULT_JSON_CALLBACK_NAME = 'weexJsonpCallback'
-
-// config.scale = window.innerWidth / DEFAULT_DESIGN_WIDTH
 
 window.WXEnvironment = {
   weexVersion: config.weexVersion,
   appName: lib.env.aliapp ? lib.env.aliapp.appname : null,
   appVersion: lib.env.aliapp ? lib.env.aliapp.version.val : null,
-  platform: lib.env.os ? lib.env.os.name : null,
-  osVersion: lib.env.os ? lib.env.os.version.val : null,
-  deviceHeight: window.innerHeight / config.scale
+  platform: 'Web',
+  osName: lib.env.browser ? lib.env.browser.name : null,
+  osVersion: lib.env.browser ? lib.env.browser.version.val : null,
+  deviceHeight: window.innerHeight / DEFAULT_SCALE
 }
 
 var _instanceMap = {}


### PR DESCRIPTION
Defintion of the three specific fields on Web platform:
- platform: always 'Web' for the platform field
- osName: browser name (including 'iOS Webview' for ios' webview and 'Chrome Webview' for android's webview)
- osVersion: browser version
