### PR TITLE
* [doc] add weex-toolkit way

### DIFF
--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -1,38 +1,63 @@
 # Scripts
-
 There are several scripts for end-user and developer.
+
+after install [WeexToolkit](https://www.npmjs.com/package/weex-toolkit), many of them can be easily and flexible processed using system global CMD `weex`.
+
 
 ## For end-user
 
-**clean `*.js` in `examples/build` and `test/build` folders**
+### clean `*.js` in `examples/build` and `test/build` folders
 ```shell
 npm run clean
 ```
 
-**create `.we` file(run `npm run create -- -h` for help)**
+### create `.we` file(run `npm run create -- -h` for help)**
 ```shell
 npm run create -- [name] -o [directory]
 ```
 
-**transform `*.we` in `examples` and `test` folders**
+### transform `*.we` in `examples` and `test` folders**
 ```shell
 npm run transform
 ```
 
-**npm run clean && npm run transform**
+#### using WeexToolkit
+```shell
+$weex test/ -o test/build;
+$weex examples/ -o examples/build;
+```
+
+`we file` in directory test/ and examples/  will be transform to JS bundle in corresponding directory.
+
+### npm run clean && npm run transform**
 ```shell
 npm run dev
 ```
 
-**run a file server at `12580` port**
+### run a file server at `12580` port**
 ```shell
 npm run serve
 ```
 
-**run a watcher for `*.we` changed**
+#### using WeexToolkit
+```shell
+$ weex -s examples/ --port 12580
+```
+`we file` in directory examples will be transform to JS bundle on every time access.
+
+
+### run a watcher for `*.we` changed
 ```shell
 npm run watch
 ```
+
+#### using WeexToolkit
+```shell
+$ weex test/ -o test/build/ --watch
+```
+
+every time you update `we file` in test/ directory  , corresponding JS bundle in  test/build/ directory will be update.
+
 
 ## For SDK Developer
 


### PR DESCRIPTION
i think move some dev bootstrap process to standalone CLI will reduce weex setup burden and make weex dev more flexible.