### PR TITLE
html5 fix index for move elements inside the same parent

### DIFF
--- a/src/h5-render/src/componentManager.js
+++ b/src/h5-render/src/componentManager.js
@@ -195,8 +195,21 @@ ComponentManager.prototype = {
       return
     }
 
-    // fire event for rendering dom on body elment.
+    // fire event for rendering.
     this.rendering()
+
+    if (index < -1) {
+      index = -1
+      console.warn('index cannot be less than -1.')
+    }
+
+    children = newParent.data.children
+    if (children
+        && children.length
+        && index !== -1
+        && index < children.length) {
+      before = this.componentMap[newParent.data.children[index].ref]
+    }
 
     // remove from oldParent.data.children
     if (oldParentRef && this.componentMap[oldParentRef]) {
@@ -213,21 +226,7 @@ ComponentManager.prototype = {
       }
     }
 
-    if (index < -1) {
-      index = -1
-      console.warn('index cannot be less than -1.')
-    }
-
-    children = newParent.data.children
-    if (children
-        && children.length
-        && index !== -1
-        && index < children.length) {
-      before = this.componentMap[newParent.data.children[index].ref]
-      newParent.insertBefore(component, before)
-    } else {  // append
-      newParent.insertBefore(component)
-    }
+    newParent.insertBefore(component, before)
 
     component.onMove && component.onMove(parentRef, index)
 


### PR DESCRIPTION
When moving a child element from a parent to the parent it self, but with a different index and position inside it, the code doesn't work correctly. This MR should fix this problem.
