### PR TITLE
html5 fix default border style of image

### DIFF
--- a/src/h5-render/src/styles/image.css
+++ b/src/h5-render/src/styles/image.css
@@ -4,4 +4,5 @@
   background-repeat: no-repeat;
   background-size: 100% 100%;
   background-position: 50%;
+  border: 0 solid black;
 }


### PR DESCRIPTION
Add `border-style: solid` and `border-color: black` for image component by default, for the consistency experience among native and web platforms.
