### PR TITLE
* [doc] fix gitbook version

### DIFF
--- a/doc/book.json
+++ b/doc/book.json
@@ -1,5 +1,5 @@
 {
-"gitbook":"3.0.0-pre.15",     
+"gitbook":"3.0.3",     
 "plugins": [
         "theme-default"
     ]


### PR DESCRIPTION
the old gitbook version will generate a error http:/xx.jpg link for img and can't render by browser if you use nginx server the book html
