### PR TITLE
* [html5] fix text's word-wrap

### DIFF
--- a/src/h5-render/src/components/text.js
+++ b/src/h5-render/src/components/text.js
@@ -23,6 +23,7 @@ Text.prototype.create = function () {
   // Give the developers the ability to control space
   // and line-breakers.
   this.textNode.style.whiteSpace = 'pre-wrap'
+  this.textNode.style.wordWrap = 'break-word'
   this.textNode.style.display = '-webkit-box'
   this.textNode.style.webkitBoxOrient = 'vertical'
   this.style.lines.call(this, this.data.style.lines)

--- a/test/text-word-wrap.we
+++ b/test/text-word-wrap.we
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <text style="font-size:30;margin-left: 10;color:#0000ff;width:500;background-color:#00FF00;">{{title}}</text>
+  </div>
+</template>
+
+<script>
+  module.exports = {
+    data: {
+      title:'{"fontSize":40,"marginTop":15,"marginLeft":15,"marginBottom":15,"marginRight":15,"textDecoration":"underline","color":"#33a3dc","width":500,"height":50,"borderWidth":3,"borderColor":"#cccccc","overflow":"hidden","borderStyle":"solid","textAlign":"center","borderRadius":5}',
+    },
+  }
+</script>


### PR DESCRIPTION
add `word-wrap:break-word` to text to break words in case the unbreakable text is too long.
