### PR TITLE
Fix iOS crash

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.h
@@ -15,6 +15,7 @@ extern void WXPerformBlockOnComponentThread(void (^block)());
 @interface WXComponentManager : NSObject
 
 @property (nonatomic, readonly, weak) WXSDKInstance *weexInstance;
+@property (nonatomic, readonly, assign) BOOL isValid;
 
 /**
  * @abstract initialize with weex instance

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -24,6 +24,7 @@ static NSThread *WXComponentThread;
 @implementation WXComponentManager
 {
     __weak WXSDKInstance *_weexInstance;
+    BOOL _isValid;
     
     BOOL _stopRunning;
     NSUInteger _noTaskTickCount;
@@ -57,6 +58,7 @@ static NSThread *WXComponentThread;
         _indexDict = [NSMapTable strongToWeakObjectsMapTable];
         _fixedComponents = [NSMutableArray wx_mutableArrayUsingWeakReferences];
         _uiTaskQueue = [NSMutableArray array];
+        _isValid = YES;
         
         [self _startDisplayLink];
     }
@@ -412,6 +414,13 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     _rootComponent = nil;
     
     [self _stopDisplayLink];
+    
+    _isValid = NO;
+}
+
+- (BOOL)isValid
+{
+    return _isValid;
 }
 
 #pragma mark Layout Batch

--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -202,7 +202,7 @@ NSTimeInterval JSLibInitTime = 0;
     
     __weak typeof(self) weakSelf = self;
     WXPerformBlockOnComponentThread(^{
-        [self.componentManager unload];
+        [weakSelf.componentManager unload];
         dispatch_async(dispatch_get_main_queue(), ^{
             [WXSDKManager removeInstanceforID:weakSelf.instanceId];
         });

--- a/ios/sdk/WeexSDK/Sources/Module/WXDomModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXDomModule.m
@@ -44,6 +44,9 @@ WX_EXPORT_METHOD(@selector(updateAttrs:attrs:))
     
     WXPerformBlockOnComponentThread(^{
         WXComponentManager *mananger = weakSelf.weexInstance.componentManager;
+        if (!mananger.isValid) {
+            return;
+        }
         [mananger startComponentTasks];
         block(mananger);
     });


### PR DESCRIPTION
Stop the component's task submitting when instance is destroyed and manager is unload.  Fix #457 
