### PR TITLE
+ [jsfm] added custom downgrade feature

### DIFF
--- a/html5/test/unit/default/app/downgrade.js
+++ b/html5/test/unit/default/app/downgrade.js
@@ -147,5 +147,95 @@ describe('downgrade', () => {
         expect(test.isDowngrade).to.be.equal(should)
       })
     })
+
+    it('should be using using custom check', () => {
+      const deviceInfo = {
+        platform: 'iOS',
+        osVersion: '9.2',
+        appVersion: '5.4.0',
+        weexVersion: '1.3.0',
+        deviceModel: 'iPhone6.2'
+      }
+
+      const cases = [
+        [
+          function () {
+
+          }, false
+        ],
+        [
+          function () {
+            return true
+          }, true
+        ],
+        [
+          function () {
+            return false
+          }, false
+        ],
+        [
+          function (deviceInfo) {
+            if (deviceInfo.platform === 'iOS') {
+              return true
+            }
+            return false
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            if (deviceInfo.osVersion === '9.2') {
+              return true
+            }
+            return false
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            if (tools.normalizeVersion(deviceInfo.osVersion) === '9.2.0') {
+              return true
+            }
+            return false
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            return tools.semver.satisfies(tools.normalizeVersion(deviceInfo.osVersion), '9.2.0')
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            return tools.semver.satisfies(deviceInfo.appVersion, '5.4.0')
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            return tools.semver.satisfies(deviceInfo.weexVersion, '1.3.0')
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            return deviceInfo.deviceModel === 'iPhone6.2'
+          }, true
+        ],
+        [
+          function (deviceInfo, tools) {
+            return deviceInfo.deviceModel === 'AndroidPad'
+          }, false
+        ],
+        [
+          function (deviceInfo, tools) {
+            return ['iPhone6.2', 'iPhone7.1'].indexOf(deviceInfo.deviceModel) >= 0
+          }, true
+        ]
+      ]
+
+      cases.map(function (item, index) {
+        const criteria = item[0]
+        const should = item[1]
+        const test = Downgrade.check(criteria, deviceInfo)
+
+        expect(test.isDowngrade).to.be.equal(should)
+      })
+    })
   })
 })


### PR DESCRIPTION
add new feature about downgrade. The new downgrade feature support custom function to downgrade. Example as code.

```
<script type="config">
{
    downgrade: function (deviceInfo, tools) {
        if (deviceInfo.osVersion === '1.0') {
            return true;
        }
        else if (tools.semver.satisfies(deviceInfo.appVersion, '>=1.0.0')) {
            // semver.satisfies only support full version format. i.e. '1.0.0', '2.3.4', ...
            // semver is https://github.com/npm/node-semver
            return true;
        }
        else if (tools.semver.satisfies(tools.normalizeVersion(deviceInfo.appVersion), '1.0.0')) {
            // tools.normalizeVersion will force normalize version.
            // ie. '1' -> '1.0.0', '1.0' -> '1.0.0', '1.2.3.4' -> '1.2.3'
            return true;
        }

        // return true is downgrade.
        return false;
    }
}
</script>
```

The old format are also supported.

```
<script type="config">
{
    downgrade: {
        ios: {
            osVersion: '>1.0.0',
            appVersion: '>1.0.0',
            weexVersion: '>1.0.0',
            deviceModel: ['modelA', 'modelB', ...]
        },
        android: {
            osVersion: '>1.0.0',
            appVersion: '>1.0.0',
            weexVersion: '>1.0.0',
            deviceModel: 'modelC'
        }
    }
}
</script>
```
