### PR TITLE
Use `copy` for `NSString`, `NSArray` and `NSDictionary` properties

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.h
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.h
@@ -39,22 +39,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  @abstract The component's identifier string.
  */
-@property (nonatomic, readonly, strong) NSString *ref;
+@property (nonatomic, readonly, copy) NSString *ref;
 
 /**
  *  @abstract The component's styles.
  */
-@property (nonatomic, readonly, strong) NSDictionary *styles;
+@property (nonatomic, readonly, copy) NSDictionary *styles;
 
 /**
  *  @abstract The component's attributes.
  */
-@property (nonatomic, readonly, strong) NSDictionary *attributes;
+@property (nonatomic, readonly, copy) NSDictionary *attributes;
 
 /**
  *  @abstract The component's events.
  */
-@property (nonatomic, readonly, strong) NSArray *events;
+@property (nonatomic, readonly, copy) NSArray *events;
 
 /**
  *  @abstract The reference to
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract The component's subcomponents.
  */
-@property (nonatomic, readonly, strong, nullable) NSArray<WXComponent *> *subcomponents;
+@property (nonatomic, readonly, copy, nullable) NSArray<WXComponent *> *subcomponents;
 
 /**
  * @abstract The component's supercomponent.

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
@@ -61,8 +61,8 @@
         pthread_mutexattr_settype(&_propertMutexAttr, PTHREAD_MUTEX_RECURSIVE);
         pthread_mutex_init(&_propertyMutex, &_propertMutexAttr);
         
-        _ref = ref;
-        _type = type;
+        _ref = [ref copy];
+        _type = [type copy];
         _weexInstance = weexInstance;
         _styles = styles ? [NSMutableDictionary dictionaryWithDictionary:styles] : [NSMutableDictionary dictionary];
         _attributes = attributes ? [NSMutableDictionary dictionaryWithDictionary:attributes] : [NSMutableDictionary dictionary];
@@ -110,7 +110,7 @@
     styles = _styles;
     pthread_mutex_unlock(&_propertyMutex);
     
-    return styles;
+    return [styles copy];
 }
 
 - (NSDictionary *)attributes
@@ -120,7 +120,7 @@
     attributes = _attributes;
     pthread_mutex_unlock(&_propertyMutex);
     
-    return attributes;
+    return [attributes copy];
 }
 
 - (NSArray *)events
@@ -254,7 +254,7 @@
     subcomponents = _subcomponents;
     pthread_mutex_unlock(&_propertyMutex);
     
-    return subcomponents;
+    return [subcomponents copy];
 }
 
 - (WXComponent *)supercomponent


### PR DESCRIPTION
Try to improve the code quality for avoid pass mutable object out which may cause potential issues. 
