### PR TITLE
[jsfm] new mechanism for build frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ pids
 *.pid
 *.seed
 
+# build framework options by script
+html5/runtime/frameworks.js
+
 # e2e test
 html5/test/e2e/reports
 html5/test/e2e/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ pids
 *.seed
 
 # build framework options by script
-html5/runtime/frameworks.js
+html5/runtime/config.js
 
 # e2e test
 html5/test/e2e/reports

--- a/build/config.frameworks.js
+++ b/build/config.frameworks.js
@@ -1,0 +1,51 @@
+// read all files framework-*.js
+// filter by args
+// generate frameworks.js
+
+var select
+if (process.argv[2]) {
+  select = process.argv[2].toLowerCase().split(',')
+}
+
+var path = require('path')
+var fs = require('fs')
+
+var dirPath = path.resolve(__dirname, '..', 'html5', 'runtime')
+
+function getAllFrameworkNames () {
+  var files = fs.readdirSync(dirPath)
+  return files.filter(function (name) {
+    return name.match(/^framework-/)
+  }).map(function (filename) {
+    return filename.replace(/^framework-(.+)\.js$/, '$1')
+  }).filter(function (name) {
+    return !select || select.indexOf(name) >= 0
+  }).map(function (name) {
+    var filePath = path.join(dirPath, 'framework-' + name + '.js')
+    return {
+      name: name.charAt(0).toUpperCase() + name.slice(1),
+      content: fs.readFileSync(filePath, { encoding: 'utf8' })
+    }
+  })
+}
+
+function generateContent () {
+  var frameworks = getAllFrameworkNames()
+  var content = []
+  var names = []
+  frameworks.forEach(function (framework) {
+    content.push(framework.content.trim())
+    names.push('  ' + framework.name)
+  })
+  return '// built by npm run build:config\n\n' +
+    content.join('\n') + '\n\n' +
+    'export default {\n' + names.join(',\n') + '\n}\n'
+}
+
+function writeContent() {
+  var content = generateContent()
+  var filePath = path.join(dirPath, 'frameworks.js')
+  fs.writeFileSync(filePath, content)
+}
+
+writeContent()

--- a/build/config.frameworks.js
+++ b/build/config.frameworks.js
@@ -44,7 +44,7 @@ function generateContent () {
 
 function writeContent() {
   var content = generateContent()
-  var filePath = path.join(dirPath, 'frameworks.js')
+  var filePath = path.join(dirPath, 'config.js')
   fs.writeFileSync(filePath, content)
 }
 

--- a/build/webpack.browser.config.js
+++ b/build/webpack.browser.config.js
@@ -2,7 +2,7 @@ var path = require('path')
 var fs = require('fs')
 
 var dirPath = path.resolve(__dirname, '..', 'html5', 'runtime')
-var filePath = path.join(dirPath, 'frameworks.js')
+var filePath = path.join(dirPath, 'config.js')
 if (!fs.existsSync(filePath)) {
   require('child_process').spawnSync('npm', ['run', 'build:config'])
 }

--- a/build/webpack.browser.config.js
+++ b/build/webpack.browser.config.js
@@ -1,3 +1,12 @@
+var path = require('path')
+var fs = require('fs')
+
+var dirPath = path.resolve(__dirname, '..', 'html5', 'runtime')
+var filePath = path.join(dirPath, 'frameworks.js')
+if (!fs.existsSync(filePath)) {
+  require('child_process').spawnSync('npm', ['run', 'build:config'])
+}
+
 var webpack = require('webpack')
 
 var pkg = require('../package.json')

--- a/build/webpack.native.config.js
+++ b/build/webpack.native.config.js
@@ -2,7 +2,7 @@ var path = require('path')
 var fs = require('fs')
 
 var dirPath = path.resolve(__dirname, '..', 'html5', 'runtime')
-var filePath = path.join(dirPath, 'frameworks.js')
+var filePath = path.join(dirPath, 'config.js')
 if (!fs.existsSync(filePath)) {
   require('child_process').spawnSync('npm', ['run', 'build:config'])
 }

--- a/build/webpack.native.config.js
+++ b/build/webpack.native.config.js
@@ -1,4 +1,14 @@
+var path = require('path')
+var fs = require('fs')
+
+var dirPath = path.resolve(__dirname, '..', 'html5', 'runtime')
+var filePath = path.join(dirPath, 'frameworks.js')
+if (!fs.existsSync(filePath)) {
+  require('child_process').spawnSync('npm', ['run', 'build:config'])
+}
+
 var webpack = require('webpack')
+
 var pkg = require('../package.json')
 
 var sourceMapPlugin = new webpack.SourceMapDevToolPlugin({
@@ -6,6 +16,7 @@ var sourceMapPlugin = new webpack.SourceMapDevToolPlugin({
 })
 
 var version = pkg.subversion.framework
+
 var date = new Date().toISOString().split('T')[0].replace(/\-/g, '')
 var banner = `(this.nativeLog || function(s) {console.log(s)})` + 
   `('START JS FRAMEWORK: ${version} Build ${date}');`;

--- a/html5/runtime/.eslintrc
+++ b/html5/runtime/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-vars": 0
+  }
+}

--- a/html5/runtime/framework-weex.js
+++ b/html5/runtime/framework-weex.js
@@ -1,5 +1,1 @@
 import * as Weex from '../default'
-
-export default {
-  Weex
-}

--- a/html5/runtime/index.js
+++ b/html5/runtime/index.js
@@ -1,4 +1,4 @@
-import frameworks from './frameworks'
+import frameworks from './config'
 
 import { Document, Element, Comment } from '../vdom'
 

--- a/html5/test/unit/default/runtime.js
+++ b/html5/test/unit/default/runtime.js
@@ -7,7 +7,7 @@ const {
 chai.use(sinonChai)
 
 import framework from '../../../runtime'
-import frameworks from '../../../runtime/frameworks'
+import frameworks from '../../../runtime/config'
 import config from '../../../default/config'
 import Vm from '../../../default/vm'
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "postinstall": "bash ./bin/install-hooks.sh",
+    "build:config": "node build/config.frameworks.js",
     "build:browser": "webpack --config build/webpack.browser.config.js",
     "build:native": "webpack --config build/webpack.native.config.js",
     "build:examples": "webpack --config build/webpack.examples.config.js",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:unit": "mocha --compilers js:babel-core/register html5/test/unit/*/*.js html5/test/unit/*/*/*.js",
     "test:cover": "babel-node node_modules/isparta/bin/isparta cover --report text node_modules/mocha/bin/_mocha -- --reporter dot html5/test/unit/*/*.js html5/test/unit/*/*/*.js",
     "test:e2e": "node html5/test/e2e/runner.js",
-    "test": "npm run lint && npm run test:cover && npm run test:e2e",
+    "test": "npm run build:config && npm run lint && npm run test:cover",
     "serve": "serve ./ -p 12580",
     "clean:examples": "echo \"\\033[36;1m[Clean]\\033[0m \\033[33mexamples\\033[0m\" && rm -vrf examples/build/*",
     "clean:test": "echo \"\\033[36;1m[Clean]\\033[0m \\033[33mtest\\033[0m\" && rm -vrf test/build/*",


### PR DESCRIPTION
Now we can use `npm run build:config` to generate `html5/runtime/frameworks.js` (this file has been ignored by git now).
This command will find all the `framework-*.js` files in `html5/runtime/` folder and register each of them to the generated file.

``` js
// built by npm run build:config

import * as Weex from '../default'
import * as Rx from 'weex-rx-framework'

export default {
  Weex,
  Rx
}
```

You can also run it like `npm run build:config -- weex,rx` to filter which frameworks we will include.
Be default the generated file `html5/runtime/frameworks.js` not existed but when we run `npm run build:native`,  `npm run build:browser` or  `npm run build` it will init once if the file hasn't been built.