### PR TITLE
Pass hotreload port as parameter

### DIFF
--- a/android/playground/app/src/main/java/com/alibaba/weex/WXPageActivity.java
+++ b/android/playground/app/src/main/java/com/alibaba/weex/WXPageActivity.java
@@ -253,8 +253,16 @@ public class WXPageActivity extends WXBaseActivity implements IWXRenderListener,
    */
   private void startHotRefresh() {
     try {
-      String host = new URL(mUri.toString()).getHost();
-      String wsUrl = "ws://" + host + ":8082";
+      String wsPortName = "wsport";
+      String url = mUri.toString();
+      String host = new URL(url).getHost();
+      String port = "8082";
+      if (url.contains(wsPortName)) {
+          port = url.split(wsPortName)[1];
+          if(port.contains("\\?"))
+              port = port.split("\\?")[0];
+      }
+      String wsUrl = "ws://" + host + ":" + port;
       mWXHandler.obtainMessage(Constants.HOT_REFRESH_CONNECT, 0, 0, wsUrl).sendToTarget();
     } catch (MalformedURLException e) {
       e.printStackTrace();

--- a/android/playground/app/src/main/java/com/alibaba/weex/WXPageActivity.java
+++ b/android/playground/app/src/main/java/com/alibaba/weex/WXPageActivity.java
@@ -253,14 +253,14 @@ public class WXPageActivity extends WXBaseActivity implements IWXRenderListener,
    */
   private void startHotRefresh() {
     try {
-      String wsPortName = "wsport";
+      String wsPortName = "wsport=";
       String url = mUri.toString();
       String host = new URL(url).getHost();
       String port = "8082";
       if (url.contains(wsPortName)) {
-          port = url.split(wsPortName)[1];
-          if(port.contains("\\?"))
-              port = port.split("\\?")[0];
+        port = url.split(wsPortName)[1];
+        if (port.contains("\\?"))
+          port = port.split("\\?")[0];
       }
       String wsUrl = "ws://" + host + ":" + port;
       mWXHandler.obtainMessage(Constants.HOT_REFRESH_CONNECT, 0, 0, wsUrl).sendToTarget();

--- a/android/playground/app/src/main/java/com/alibaba/weex/WXPageActivity.java
+++ b/android/playground/app/src/main/java/com/alibaba/weex/WXPageActivity.java
@@ -252,21 +252,13 @@ public class WXPageActivity extends WXBaseActivity implements IWXRenderListener,
    * hot refresh
    */
   private void startHotRefresh() {
-    try {
-      String wsPortName = "wsport=";
-      String url = mUri.toString();
-      String host = new URL(url).getHost();
-      String port = "8082";
-      if (url.contains(wsPortName)) {
-        port = url.split(wsPortName)[1];
-        if (port.contains("\\?"))
-          port = port.split("\\?")[0];
-      }
-      String wsUrl = "ws://" + host + ":" + port;
-      mWXHandler.obtainMessage(Constants.HOT_REFRESH_CONNECT, 0, 0, wsUrl).sendToTarget();
-    } catch (MalformedURLException e) {
-      e.printStackTrace();
+    String host = mUri.getHost();
+    String port = mUri.getQueryParameter("wsport");
+    if (port == null || port.length() == 0) {
+      port = "8082";
     }
+    String wsUrl = "ws://" + host + ":" + port;
+    mWXHandler.obtainMessage(Constants.HOT_REFRESH_CONNECT, 0, 0, wsUrl).sendToTarget();
   }
 
   private void addOnListener() {


### PR DESCRIPTION
the hot reload will not work if we change the ws port through weex tool-kit  

how to fix it :
  weex tool-kit add ws port into the js bundle url as a parameter, So the playground can get the wsport, Then hot reload can work normally. 

I have pull a request to weex tool-kit  https://github.com/weexteam/weex-toolkit/pull/7

weex 命令行在修改 wsport 的情况下, playground 就无法 hotreload 了

给 weex tool-kit 也提交了一个 pr, https://github.com/weexteam/weex-toolkit/pull/7

 意图就是让weex tool kit将 wsport 当做参数传过来, 让playground 可以解析到 wsport, 这样就可以继续 hotreload 了
