### PR TITLE
[jsfm] fixed repeat bug when update values with new object references

### DIFF
--- a/html5/default/vm/compiler.js
+++ b/html5/default/vm/compiler.js
@@ -499,6 +499,12 @@ function bindRepeat (vm, target, fragBlock, info) {
           }
           children.push(reused.target)
           vms.push(reused.vm)
+          if (oldStyle) {
+            reused.vm = item
+          }
+          else {
+            reused.vm[valueName] = item
+          }
           reused.vm[keyName] = index
           fragBlock.updateMark = reused.target
         }


### PR DESCRIPTION
Before it fixed, when the array item with the same key updated but not the same ref, the data binding of the child properties will be lost. Because the data binding still on the old data ref.

Now the new ref data will be bound automatically so the bug has been fixed.

```javascript
// init data
data: {
  list: [{x: 1}, {x: 2}, {x: 3}]
}
// update
this.list[0].x = 4 // it works both before and after this bugfix
this.list = [{x: 1}, {x: 2}, {x: 3}] // new data refs in this.list
this.list[0].x = 4 // it only works after this bugfix
```