### PR TITLE
fix e2e test ci

### DIFF
--- a/build/nightwatch.config.js
+++ b/build/nightwatch.config.js
@@ -5,7 +5,7 @@ module.exports = {
 
   'selenium': {
     'start_process': true,
-    'server_path': 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.0.jar',
+    'server_path': 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar',
     'log_path': false,
     'host': '127.0.0.1',
     'port': 4444,

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "mocha": "^2.5.3",
     "nightwatch": "^0.9.4",
     "phantomjs-prebuilt": "^2.1.7",
-    "selenium-server": "^2.53.0",
+    "selenium-server": "2.53.1",
     "serve": "^1.4.0",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
circleci fails due to selenium-server's version disagreement with nightwatch config file. Try to specify the exact version within the config file in the package.json file, not allowing version auto-updating.