### PR TITLE
example fix typo

### DIFF
--- a/examples/component/scroller-demo.we
+++ b/examples/component/scroller-demo.we
@@ -1,5 +1,5 @@
 <template>
-  <scroller class="list" append＝"tree">
+  <scroller class="list" append="tree">
 
     <refresh class="refresh-view" display="{{refresh_display}}" onrefresh="onrefresh">
       <loading-indicator style="height:60;width:60" ></loading-indicator>
@@ -85,12 +85,16 @@
       onrefresh: function(e) {
         var self = this;
         self.refresh_display = 'show';
-        self.refresh_display = 'hide';
+        setTimeout(function () {
+          self.refresh_display = 'hide';
+        }, 1000)
       },
       onloading: function(e) {
         var self = this;
         self.loading_display = 'show';
-        self.loading_display = 'hide';
+        setTimeout(function () {
+          self.loading_display = 'hide';
+        }, 1000)
       }
     },
     data: {


### PR DESCRIPTION
* fix '＝' with '='.
* with this typo fixed, the `append=tree` worked, but it appears to confront another bug from jsfm, that the `Documenet.prototype.getRef` seems not working in tree mode.