### PR TITLE
+ [jsfm] reset existing class styles before setting new styles

### DIFF
--- a/html5/test/unit/default/assets/reset-style.input
+++ b/html5/test/unit/default/assets/reset-style.input
@@ -1,0 +1,42 @@
+define('@weex-component/reset-style', function (require, exports, module) {
+
+;
+  module.exports = {
+	  data: function () {return {
+	    className: 'highlight'
+	  }},
+	  methods: {
+	    ready: function() {
+	      this.className = 'normal';
+	    }
+	  }
+  }
+
+
+;module.exports.style = {
+  "normal": {
+    "fontSize": 40
+  },
+  "highlight": {
+    "fontSize": 60,
+    "color": "#FF0000"
+  }
+}
+
+;module.exports.template = {
+  "type": "container",
+  "children": [
+    {
+      "type": "text",
+      "classList": function () {return [this.className]},
+      "attr": {
+        "value": "Hello Weex"
+      }
+    }
+  ]
+}
+
+;})
+
+
+bootstrap('@weex-component/reset-style')

--- a/html5/test/unit/default/assets/reset-style.output
+++ b/html5/test/unit/default/assets/reset-style.output
@@ -1,0 +1,15 @@
+{
+  "type": "container",
+  "children": [
+    {
+      "type": "text",
+      "attr": {
+        "value": "Hello Weex"
+      },
+      "style": {
+        "fontSize": 40,
+        "color": ""
+      }
+    }
+  ]
+}

--- a/html5/test/unit/default/test.js
+++ b/html5/test/unit/default/test.js
@@ -562,6 +562,22 @@ describe('test input and output', () => {
     delete allDocs[name]
   })
 
+  it('reset class style case', () => {
+    const name = 'reset-style'
+    const inputCode = readInput(name)
+    const outputCode = readOutput(name)
+    const doc = new Document(name)
+    allDocs[name] = doc
+
+    framework.createInstance(name, inputCode)
+    const expected = eval('(' + outputCode + ')')
+    const actual = doc.toJSON()
+    expect(actual).eql(expected)
+
+    framework.destroyInstance(name)
+    delete allDocs[name]
+  })
+
   it('dynamic type case', () => {
     const name = 'dynamic-type'
     const inputCode = readInput(name)

--- a/html5/test/unit/default/test.js
+++ b/html5/test/unit/default/test.js
@@ -571,8 +571,15 @@ describe('test input and output', () => {
 
     framework.createInstance(name, inputCode)
     const expected = eval('(' + outputCode + ')')
-    const actual = doc.toJSON()
-    expect(actual).eql(expected)
+
+    framework.callJS(name, [{
+      method: 'fireEvent',
+      args: [doc.body.children[0].ref, 'click', {}]
+    }])
+
+    setTimeout(function () {
+      expect(doc.toJSON()).eql(expected)
+    }, 0)
 
     framework.destroyInstance(name)
     delete allDocs[name]

--- a/html5/vdom/index.js
+++ b/html5/vdom/index.js
@@ -465,8 +465,15 @@ Element.prototype.setStyle = function (key, value, silent) {
   }
 }
 
+Element.prototype.resetClassStyle = function () {
+  for (const key in this.classStyle) {
+    this.classStyle[key] = ''
+  }
+}
+
 Element.prototype.setClassStyle = function (classStyle) {
-  this.classStyle = classStyle
+  this.resetClassStyle()
+  extend(this.classStyle, classStyle)
   if (this.docId) {
     const listener = instanceMap[this.docId].listener
     listener.setStyles(this.ref, this.toStyle())


### PR DESCRIPTION
Reset the element's existing class styles, while it changes the class name. According to CSS spec, I use the empty string to reset the style.

See the [issue #397](https://github.com/alibaba/weex/issues/397).