### PR TITLE
+ [jsfm] Add `off` log level to prevent all console outputs

### DIFF
--- a/html5/shared/console.js
+++ b/html5/shared/console.js
@@ -8,7 +8,7 @@
  */
 
 const { console, nativeLog } = global
-const LEVELS = ['error', 'warn', 'info', 'log', 'debug']
+const LEVELS = ['off', 'error', 'warn', 'info', 'log', 'debug']
 const levelMap = {}
 
 generateLevelMap()


### PR DESCRIPTION
Add `off` log level to prevent all console outputs. See details in #966 .