### PR TITLE
Do not pollute `window.document` on web platform

### DIFF
--- a/html5/default/app/ctrl.js
+++ b/html5/default/app/ctrl.js
@@ -137,7 +137,7 @@ export function init (code, data) {
     fn(
       bundleDefine,
       bundleRequire,
-      window.document,
+      typeof window !== 'undefined' ? window.document : bundleDocument,
       bundleBootstrap,
       bundleRegister,
       bundleRender,

--- a/html5/default/app/ctrl.js
+++ b/html5/default/app/ctrl.js
@@ -137,7 +137,7 @@ export function init (code, data) {
     fn(
       bundleDefine,
       bundleRequire,
-      bundleDocument,
+      window.document,
       bundleBootstrap,
       bundleRegister,
       bundleRender,


### PR DESCRIPTION
Or maybe is there any specific reason to do so?