### PR TITLE
+ [jsfm] Make the destroy logic of app instance more reliable

### DIFF
--- a/html5/default/app/ctrl/misc.js
+++ b/html5/default/app/ctrl/misc.js
@@ -45,7 +45,7 @@ export function destroy (app) {
   console.debug(`[JS Framework] Destory an instance(${app.id})`)
 
   if (app.vm) {
-    app.vm.destroy()
+    destroyVm(app.vm)
   }
 
   app.id = ''
@@ -56,6 +56,43 @@ export function destroy (app) {
   app.doc = null
   app.customComponentMap = null
   app.callbacks = null
+}
+
+/**
+ * Destroy an Vm.
+ * @param {object} vm
+ */
+export function destroyVm (vm) {
+  delete vm._app
+  delete vm._computed
+  delete vm._css
+  delete vm._data
+  delete vm._ids
+  delete vm._methods
+  delete vm._options
+  delete vm._parent
+  delete vm._parentEl
+  delete vm._rootEl
+  delete vm._vmEvents
+  delete vm._type
+
+  // remove all watchers
+  if (vm._watchers) {
+    let watcherCount = vm._watchers.length
+    while (watcherCount--) {
+      vm._watchers[watcherCount].teardown()
+    }
+    delete vm._watchers
+  }
+
+  // remove child vms recursively
+  if (vm._childrenVms) {
+    let vmCount = vm._childrenVms.length
+    while (vmCount--) {
+      destroyVm(vm._childrenVms[vmCount])
+    }
+    delete vm._childrenVms
+  }
 }
 
 /**

--- a/html5/default/app/ctrl/misc.js
+++ b/html5/default/app/ctrl/misc.js
@@ -44,6 +44,10 @@ export function refresh (app, data) {
 export function destroy (app) {
   console.debug(`[JS Framework] Destory an instance(${app.id})`)
 
+  if (app.vm) {
+    app.vm.destroy()
+  }
+
   app.id = ''
   app.options = null
   app.blocks = null

--- a/html5/default/vm/index.js
+++ b/html5/default/vm/index.js
@@ -82,4 +82,37 @@ export default function Vm (
   build(this)
 }
 
+Vm.prototype.destroy = function () {
+  delete this._app
+  delete this._computed
+  delete this._css
+  delete this._data
+  delete this._ids
+  delete this._methods
+  delete this._options
+  delete this._parent
+  delete this._parentEl
+  delete this._rootEl
+  delete this._vmEvents
+  delete this._type
+
+  // remove all watchers
+  if (this._watchers) {
+    let watcherCount = this._watchers.length
+    while (watcherCount--) {
+      this._watchers[watcherCount].teardown()
+    }
+    delete this._watchers
+  }
+
+  // remove child vms recursively
+  if (this._childrenVms) {
+    let vmCount = this._childrenVms.length
+    while (vmCount--) {
+      this._childrenVms[vmCount].destroy()
+    }
+    delete this._childrenVms
+  }
+}
+
 mixinEvents(Vm.prototype)

--- a/html5/default/vm/index.js
+++ b/html5/default/vm/index.js
@@ -82,37 +82,4 @@ export default function Vm (
   build(this)
 }
 
-Vm.prototype.destroy = function () {
-  delete this._app
-  delete this._computed
-  delete this._css
-  delete this._data
-  delete this._ids
-  delete this._methods
-  delete this._options
-  delete this._parent
-  delete this._parentEl
-  delete this._rootEl
-  delete this._vmEvents
-  delete this._type
-
-  // remove all watchers
-  if (this._watchers) {
-    let watcherCount = this._watchers.length
-    while (watcherCount--) {
-      this._watchers[watcherCount].teardown()
-    }
-    delete this._watchers
-  }
-
-  // remove child vms recursively
-  if (this._childrenVms) {
-    let vmCount = this._childrenVms.length
-    while (vmCount--) {
-      this._childrenVms[vmCount].destroy()
-    }
-    delete this._childrenVms
-  }
-}
-
 mixinEvents(Vm.prototype)


### PR DESCRIPTION
Destroy the `vm` property recursively when destroy an app instance.

Set `app.vm = null` works well in most cases, but if developer cache the sub vm on somewhere (e.g. window), it may not destroyed entirety.