### PR TITLE
[jsfm] supported weex-x in the future

### DIFF
--- a/html5/browser/runtime/app/ctrl/init.js
+++ b/html5/browser/runtime/app/ctrl/init.js
@@ -7,6 +7,7 @@
  * corresponded with the API of instance manager (framework.js)
  */
 
+import Vm from '../../../../default/vm'
 import { removeWeexPrefix } from '../../../../default/util'
 import {
   defineFn,
@@ -33,6 +34,7 @@ export function init (app, code, data) {
     app.doc.listener.createFinish()
     console.debug(`[JS Framework] After intialized an instance(${app.id})`)
   }
+  bundleBootstrap.Vm = Vm
   const bundleRegister = (...args) => register(app, ...args)
   const bundleRender = (name, _data) => {
     result = bootstrap(app, name, {}, _data)

--- a/html5/browser/runtime/app/ctrl/init.js
+++ b/html5/browser/runtime/app/ctrl/init.js
@@ -34,7 +34,7 @@ export function init (app, code, data) {
     app.doc.listener.createFinish()
     console.debug(`[JS Framework] After intialized an instance(${app.id})`)
   }
-  bundleBootstrap.Vm = Vm
+  const bundleVm = Vm
   const bundleRegister = (...args) => register(app, ...args)
   const bundleRender = (name, _data) => {
     result = bootstrap(app, name, {}, _data)
@@ -72,6 +72,7 @@ export function init (app, code, data) {
       '__weex_bootstrap__', // alias for bootstrap
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
+      '__weex_viewmodel__',
       functionBody
     )
 
@@ -85,7 +86,8 @@ export function init (app, code, data) {
       bundleDefine,
       bundleBootstrap,
       bundleDocument,
-      bundleRequireModule)
+      bundleRequireModule,
+      bundleVm)
   }
 
   return result

--- a/html5/default/app/ctrl/init.js
+++ b/html5/default/app/ctrl/init.js
@@ -7,6 +7,7 @@
  * corresponded with the API of instance manager (framework.js)
  */
 
+import Vm from '../../vm'
 import { removeWeexPrefix } from '../../util'
 import {
   defineFn,
@@ -33,6 +34,7 @@ export function init (app, code, data) {
     app.doc.listener.createFinish()
     console.debug(`[JS Framework] After intialized an instance(${app.id})`)
   }
+  bundleBootstrap.Vm = Vm
   const bundleRegister = (...args) => register(app, ...args)
   const bundleRender = (name, _data) => {
     result = bootstrap(app, name, {}, _data)

--- a/html5/default/app/ctrl/init.js
+++ b/html5/default/app/ctrl/init.js
@@ -34,7 +34,7 @@ export function init (app, code, data) {
     app.doc.listener.createFinish()
     console.debug(`[JS Framework] After intialized an instance(${app.id})`)
   }
-  bundleBootstrap.Vm = Vm
+  const bundleVm = Vm
   const bundleRegister = (...args) => register(app, ...args)
   const bundleRender = (name, _data) => {
     result = bootstrap(app, name, {}, _data)
@@ -96,6 +96,7 @@ export function init (app, code, data) {
       '__weex_bootstrap__', // alias for bootstrap
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
+      '__weex_viewmodel__',
       'setTimeout',
       'setInterval',
       'clearTimeout',
@@ -114,6 +115,7 @@ export function init (app, code, data) {
       bundleBootstrap,
       bundleDocument,
       bundleRequireModule,
+      bundleVm,
       timerAPIs.setTimeout,
       timerAPIs.setInterval,
       timerAPIs.clearTimeout,
@@ -131,6 +133,7 @@ export function init (app, code, data) {
       '__weex_bootstrap__', // alias for bootstrap
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
+      '__weex_viewmodel__',
       functionBody
     )
 
@@ -144,7 +147,8 @@ export function init (app, code, data) {
       bundleDefine,
       bundleBootstrap,
       bundleDocument,
-      bundleRequireModule)
+      bundleRequireModule,
+      bundleVm)
   }
 
   return result

--- a/html5/default/core/observer.js
+++ b/html5/default/core/observer.js
@@ -256,7 +256,7 @@ export function set (obj, key, val) {
     while (i--) {
       const vm = ob.vms[i]
       proxy(vm, key)
-      vm.$forceUpdate()
+      // vm.$forceUpdate()
     }
   }
   return val
@@ -279,7 +279,7 @@ export function del (obj, key) {
   if (!ob) {
     if (obj._isVue) {
       delete obj._data[key]
-      obj.$forceUpdate()
+      // obj.$forceUpdate()
     }
     return
   }
@@ -289,7 +289,7 @@ export function del (obj, key) {
     while (i--) {
       const vm = ob.vms[i]
       unproxy(vm, key)
-      vm.$forceUpdate()
+      // vm.$forceUpdate()
     }
   }
 }

--- a/html5/default/vm/index.js
+++ b/html5/default/vm/index.js
@@ -11,6 +11,13 @@ import {
   build
 } from './compiler'
 import {
+  set,
+  del
+} from '../core/observer'
+import {
+  watch
+} from './directive'
+import {
   initEvents,
   mixinEvents
 } from './events'
@@ -33,13 +40,16 @@ export default function Vm (
   mergedData,
   externalEvents
 ) {
+  parentVm = parentVm || {}
   this._parent = parentVm._realParent ? parentVm._realParent : parentVm
-  this._app = parentVm._app
+  this._app = parentVm._app || {}
   parentVm._childrenVms && parentVm._childrenVms.push(this)
 
-  if (!options) {
-    options = this._app.customComponentMap[type] || {}
+  if (!options && this._app.customComponentMap) {
+    options = this._app.customComponentMap[type]
   }
+  options = options || {}
+
   const data = options.data || {}
 
   this._options = options
@@ -77,9 +87,27 @@ export default function Vm (
     options.methods.ready.call(this)
   }
 
+  if (!this._app.doc) {
+    return
+  }
+
   // if no parentElement then specify the documentElement
   this._parentEl = parentEl || this._app.doc.documentElement
   build(this)
 }
 
 mixinEvents(Vm.prototype)
+
+/**
+ * Watch an function and bind all the data appeared in it. When the related
+ * data changes, the callback will be called with new value as 1st param.
+ *
+ * @param {Function} fn
+ * @param {Function} callback
+ */
+Vm.prototype.$watch = function (fn, callback) {
+  watch(this, fn, callback)
+}
+
+Vm.set = set
+Vm.delete = del


### PR DESCRIPTION
supported `weex-x` in the future

1. exported `__weex_viewmodel__` to instance env.
2. added API `Vm.set` and `Vm.del`.
3. added API `Vm.prototype.$watch`.
4. supported `new Vm` without app or document (so the `compile()` process will be skipped).

Test case will more depend on `weex-x` [examples](https://github.com/Jinjiang/weex-x/tree/master/examples/src) and [test](https://github.com/Jinjiang/weex-x/blob/master/test/index.js)

Thanks.