### PR TITLE
[jsfm] Fix watcher dismatched bug between multi instance

### DIFF
--- a/html5/default/core/dep.js
+++ b/html5/default/core/dep.js
@@ -20,6 +20,16 @@ export default function Dep () {
 // this is globally unique because there could be only one
 // watcher being evaluated at any time.
 Dep.target = null
+const targetStack = []
+
+export function pushTarget (_target) {
+  if (Dep.target) targetStack.push(Dep.target)
+  Dep.target = _target
+}
+
+export function popTarget () {
+  Dep.target = targetStack.pop()
+}
 
 /**
  * Add a directive subscriber.

--- a/html5/default/core/dep.js
+++ b/html5/default/core/dep.js
@@ -56,7 +56,9 @@ Dep.prototype.removeSub = function (sub) {
  */
 
 Dep.prototype.depend = function () {
-  Dep.target.addDep(this)
+  if (Dep.target) {
+    Dep.target.addDep(this)
+  }
 }
 
 /**

--- a/html5/default/core/watcher.js
+++ b/html5/default/core/watcher.js
@@ -79,23 +79,16 @@ export default function Watcher (vm, expOrFn, cb, options) {
  */
 
 Watcher.prototype.get = function () {
-  this.beforeGet()
+  pushTarget(this)
   const value = this.getter.call(this.vm, this.vm)
   // "touch" every property so they are all tracked as
   // dependencies for deep watching
   if (this.deep) {
     traverse(value)
   }
-  this.afterGet()
+  popTarget()
+  this.cleanupDeps()
   return value
-}
-
-/**
- * Prepare for dependency collection.
- */
-
-Watcher.prototype.beforeGet = function () {
-  pushTarget(this)
 }
 
 /**
@@ -119,8 +112,7 @@ Watcher.prototype.addDep = function (dep) {
  * Clean up for dependency collection.
  */
 
-Watcher.prototype.afterGet = function () {
-  popTarget()
+Watcher.prototype.cleanupDeps = function () {
   let i = this.deps.length
   while (i--) {
     const dep = this.deps[i]
@@ -197,12 +189,8 @@ Watcher.prototype.run = function () {
  */
 
 Watcher.prototype.evaluate = function () {
-  // avoid overwriting another watcher that is being
-  // collected.
-  const current = Dep.target
   this.value = this.get()
   this.dirty = false
-  Dep.target = current
 }
 
 /**

--- a/html5/default/core/watcher.js
+++ b/html5/default/core/watcher.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import Dep from './dep'
+import Dep, { pushTarget, popTarget } from './dep'
 // import { pushWatcher } from './batcher'
 import {
   warn,
@@ -96,8 +96,7 @@ Watcher.prototype.get = function () {
  */
 
 Watcher.prototype.beforeGet = function () {
-  prevTarget = Dep.target
-  Dep.target = this
+  pushTarget(this)
 }
 
 /**
@@ -122,7 +121,7 @@ Watcher.prototype.addDep = function (dep) {
  */
 
 Watcher.prototype.afterGet = function () {
-  Dep.target = prevTarget
+  popTarget()
   let i = this.deps.length
   while (i--) {
     const dep = this.deps[i]

--- a/html5/default/core/watcher.js
+++ b/html5/default/core/watcher.js
@@ -13,7 +13,6 @@ import {
 } from '../util'
 
 let uid = 0
-let prevTarget
 
 /**
  * A watcher parses an expression, collects dependencies,


### PR DESCRIPTION
In data-bing logic, the `prevTarget` will store the last watcher which couldn't be destroyed while switching app instance. And the prevTarget state is dismatched when evaluating computed lazy watcher.

 + change prevTarget to a stack
 + move the target operation to dep.js

See more details at [vue issue #3133](https://github.com/vuejs/vue/issues/3133)