### PR TITLE
+ [android] add line number before log content

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
@@ -259,6 +259,7 @@ public class WXEnvironment {
   public static LogLevel sLogLevel= LogLevel.DEBUG;
   private static boolean isApkDebug = true;
   private static boolean isPerf = false;
+  private static boolean isShowLineNumber = true;
 
   public static boolean sShow3DLayer=true;
 
@@ -350,6 +351,10 @@ public class WXEnvironment {
 
   public static boolean isPerf() {
     return isPerf;
+  }
+
+  public static boolean isShowLineNumber() {
+    return isShowLineNumber;
   }
 
   private static String getDevId() {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXScrollView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXScrollView.java
@@ -383,6 +383,7 @@ public class WXScrollView extends ScrollView implements Callback, IWXScroller,
       MotionEvent down = MotionEvent.obtain(ev);
       down.setAction(MotionEvent.ACTION_DOWN);
       mHasNotDoneActionDown = false;
+      down.recycle();
     }
 
     if (ev.getAction() == MotionEvent.ACTION_DOWN) {

--- a/android/sdk/src/main/java/com/taobao/weex/utils/WXLogUtils.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/WXLogUtils.java
@@ -131,13 +131,14 @@ public class WXLogUtils {
     if (WXEnvironment.isApkDebugable() || WXEnvironment.isPerf()) {
       builder.setLength(0);
       builder.append("[render time]").append(type).append(":").append(time);
-      Log.d(WEEX_PERF_TAG, builder.substring(0));
+      Log.d(WEEX_PERF_TAG, getLineNumber() + builder.substring(0));
       writeConsoleLog("debug", builder.substring(0));
     }
   }
 
   public static void d(String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.d(WEEX_TAG, msg);
       writeConsoleLog("debug", msg);
       sendLog(LogLevel.DEBUG, msg);
@@ -146,6 +147,7 @@ public class WXLogUtils {
 
   public static void info(String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.i(WEEX_TAG, msg);
       writeConsoleLog("info", msg);
       sendLog(LogLevel.INFO,msg);
@@ -154,6 +156,7 @@ public class WXLogUtils {
 
   public static void v(String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.v(WEEX_TAG, msg);
       writeConsoleLog("verbose", msg);
       sendLog(LogLevel.VERBOSE, msg);
@@ -162,6 +165,7 @@ public class WXLogUtils {
 
   public static void w(String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.w(WEEX_TAG, msg);
       writeConsoleLog("warning", msg);
       sendLog(LogLevel.WARN, msg);
@@ -170,6 +174,7 @@ public class WXLogUtils {
 
   public static void e(String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.e(WEEX_TAG, msg);
       writeConsoleLog("error", msg);
       sendLog(LogLevel.ERROR, msg);
@@ -178,6 +183,7 @@ public class WXLogUtils {
 
   public static void d(String tag, String msg) {
     if (WXEnvironment.isApkDebugable() && !TextUtils.isEmpty(msg)) {
+      msg = getLineNumber() + msg;
       Log.d(tag, msg);
       writeConsoleLog("debug", tag + ":" + msg);
       if(msg.contains(" | __")){
@@ -211,6 +217,7 @@ public class WXLogUtils {
 
   public static void i(String tag, String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.i(tag, msg);
       writeConsoleLog("info", tag + ":" + msg);
       sendLog(LogLevel.INFO, tag+":"+msg);
@@ -219,6 +226,7 @@ public class WXLogUtils {
 
   public static void v(String tag, String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.v(tag, msg);
       writeConsoleLog("verbose", tag + ":" + msg);
       sendLog(LogLevel.VERBOSE, tag+":"+msg);
@@ -227,6 +235,7 @@ public class WXLogUtils {
 
   public static void w(String tag, String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.w(tag, msg);
       writeConsoleLog("warning", tag + ":" + msg);
       sendLog(LogLevel.WARN, tag+":"+msg);
@@ -235,6 +244,7 @@ public class WXLogUtils {
 
   public static void e(String tag, String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.e(tag, msg);
       writeConsoleLog("error", tag + ":" + msg);
       sendLog(LogLevel.ERROR, tag+":"+msg);
@@ -243,6 +253,7 @@ public class WXLogUtils {
 
   public static void p(String msg) {
     if (WXEnvironment.isApkDebugable() && msg != null) {
+      msg = getLineNumber() + msg;
       Log.d(WEEX_PERF_TAG, msg);
       writeConsoleLog("debug", msg);
     }
@@ -341,5 +352,26 @@ public class WXLogUtils {
         Log.d("weex","WXDebugTool not found!");
       }
     }
+  }
+
+  /**
+   * Why the index is 4 ?
+   * StackTrace:
+   * 0 = dalvik.system.VMStack.getThreadStackTrace
+   * 1 = java.lang.Thread.getStackTrace
+   * 2 = com.taobao.weex.utils.WXLogUtils.getLineNumber
+   * 3 = com.taobao.weex.utils.WXLogUtils.x
+   * 4 = the actual caller
+   * …… more stack trace element
+   * */
+  private static String getLineNumber() {
+    if (!WXEnvironment.isApkDebugable()) {
+      return "";
+    }
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    int index = 4;
+    String className = stackTrace[index].getFileName();
+    int lineNum = stackTrace[index].getLineNumber();
+    return "(" + className + ":" + lineNum + ") ";
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/utils/WXLogUtils.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/WXLogUtils.java
@@ -355,21 +355,19 @@ public class WXLogUtils {
   }
 
   /**
-   * Why the index is 4 ?
+   * Why the index is 2 ?
    * StackTrace:
-   * 0 = dalvik.system.VMStack.getThreadStackTrace
-   * 1 = java.lang.Thread.getStackTrace
-   * 2 = com.taobao.weex.utils.WXLogUtils.getLineNumber
-   * 3 = com.taobao.weex.utils.WXLogUtils.x
-   * 4 = the actual caller
+   * 0 = com.taobao.weex.utils.WXLogUtils.getLineNumber
+   * 1 = com.taobao.weex.utils.WXLogUtils#x
+   * 2 = the actual caller
    * …… more stack trace element
    * */
   private static String getLineNumber() {
-    if (!WXEnvironment.isApkDebugable()) {
+    if (!WXEnvironment.isShowLineNumber()) {
       return "";
     }
-    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    int index = 4;
+    StackTraceElement[] stackTrace = new Throwable().getStackTrace();
+    final int index = 2;
     String className = stackTrace[index].getFileName();
     int lineNum = stackTrace[index].getLineNumber();
     return "(" + className + ":" + lineNum + ") ";


### PR DESCRIPTION
Add line number (e.g. `(WXSDKInstance.java:752) `) before log content when method `WXEnvironment.isApkDebugable()` return `true`    
It provide the ability to hyperlink to code, looks like this:    
![QQ20160830-0@2x.png](https://ooo.0o0.ooo/2016/08/30/57c4f8030b772.png)