### PR TITLE
+ [jsfm] Add `destroyed` lifecircle #862

### DIFF
--- a/html5/default/app/ctrl/misc.js
+++ b/html5/default/app/ctrl/misc.js
@@ -63,6 +63,26 @@ export function destroy (app) {
  * @param {object} vm
  */
 export function destroyVm (vm) {
+  delete vm._app
+  delete vm._computed
+  delete vm._css
+  delete vm._data
+  delete vm._ids
+  delete vm._methods
+  delete vm._options
+  delete vm._parent
+  delete vm._parentEl
+  delete vm._rootEl
+
+  // remove all watchers
+  if (vm._watchers) {
+    let watcherCount = vm._watchers.length
+    while (watcherCount--) {
+      vm._watchers[watcherCount].teardown()
+    }
+    delete vm._watchers
+  }
+
   // destroy child vms recursively
   if (vm._childrenVms) {
     let vmCount = vm._childrenVms.length
@@ -75,27 +95,8 @@ export function destroyVm (vm) {
   console.debug(`[JS Framework] "destroyed" lifecycle in Vm(${vm._type})`)
   vm.$emit('hook:destroyed')
 
-  delete vm._app
-  delete vm._computed
-  delete vm._css
-  delete vm._data
-  delete vm._ids
-  delete vm._methods
-  delete vm._options
-  delete vm._parent
-  delete vm._parentEl
-  delete vm._rootEl
-  delete vm._vmEvents
   delete vm._type
-
-  // remove all watchers
-  if (vm._watchers) {
-    let watcherCount = vm._watchers.length
-    while (watcherCount--) {
-      vm._watchers[watcherCount].teardown()
-    }
-    delete vm._watchers
-  }
+  delete vm._vmEvents
 }
 
 /**

--- a/html5/default/app/ctrl/misc.js
+++ b/html5/default/app/ctrl/misc.js
@@ -63,6 +63,18 @@ export function destroy (app) {
  * @param {object} vm
  */
 export function destroyVm (vm) {
+  // destroy child vms recursively
+  if (vm._childrenVms) {
+    let vmCount = vm._childrenVms.length
+    while (vmCount--) {
+      destroyVm(vm._childrenVms[vmCount])
+    }
+    delete vm._childrenVms
+  }
+
+  console.debug(`[JS Framework] "destroyed" lifecycle in Vm(${vm._type})`)
+  vm.$emit('hook:destroyed')
+
   delete vm._app
   delete vm._computed
   delete vm._css
@@ -83,15 +95,6 @@ export function destroyVm (vm) {
       vm._watchers[watcherCount].teardown()
     }
     delete vm._watchers
-  }
-
-  // remove child vms recursively
-  if (vm._childrenVms) {
-    let vmCount = vm._childrenVms.length
-    while (vmCount--) {
-      destroyVm(vm._childrenVms[vmCount])
-    }
-    delete vm._childrenVms
   }
 }
 

--- a/html5/default/vm/events.js
+++ b/html5/default/vm/events.js
@@ -124,7 +124,7 @@ export function $off (type, handler) {
   handlerList.$remove(handler)
 }
 
-const LIFE_CYCLE_TYPES = ['init', 'created', 'ready']
+const LIFE_CYCLE_TYPES = ['init', 'created', 'ready', 'destroyed']
 
 /**
  * Init events:


### PR DESCRIPTION
Add `destroyed` lifecircle on vm. Developers can add extra cleanup works here to prevent memory leak.

Two notices:
 1. The `destroyed` hook will be emitted before doing internal cleanup procedures.
 2. Child vms' `destroyed` hook will be emitted before there parent's.