### PR TITLE
* [android] fix crash when no permission "READ_PHONE_STATE"

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXScrollView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXScrollView.java
@@ -383,6 +383,7 @@ public class WXScrollView extends ScrollView implements Callback, IWXScroller,
       MotionEvent down = MotionEvent.obtain(ev);
       down.setAction(MotionEvent.ACTION_DOWN);
       mHasNotDoneActionDown = false;
+      down.recycle();
     }
 
     if (ev.getAction() == MotionEvent.ACTION_DOWN) {


### PR DESCRIPTION
在Android M及以上，`android.permission.READ_PHONE_STATE`权限需要在运行时动态申请，在`DebugServerProxy.java`中没有判断此权限就直接使用了`getSystemService(Context.TELEPHONY_SERVICE)`，在没有权限的情况下会导致playground发生crash，现在把这个权限和相机权限一同申请，如果拒绝了其中任意一个权限则不能打开扫码Activity也就不能触发DebugServerProxy中的逻辑
