### PR TITLE
* [jsfm] emit `destroyed` event in every cases

### DIFF
--- a/html5/default/vm/compiler.js
+++ b/html5/default/vm/compiler.js
@@ -319,7 +319,7 @@ function compileCustomComponent (vm, component, target, dest, type, meta) {
       }
     }
   })
-  bindSubVmAfterInitialized(vm, subVm, target)
+  bindSubVmAfterInitialized(vm, subVm, target, dest)
 }
 
 /**

--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -79,9 +79,17 @@ export function bindSubVm (vm, subVm, template, repeatItem) {
 /**
  * merge class and styles from vm to sub vm.
  */
-export function bindSubVmAfterInitialized (vm, subVm, template) {
+export function bindSubVmAfterInitialized (vm, subVm, template, target = {}) {
   mergeClassStyle(template.classList, vm, subVm)
   mergeStyle(template.style, vm, subVm)
+
+  // bind subVm to the target element
+  if (target.children) {
+    target.children[target.children.length - 1]._vm = subVm
+  }
+  else {
+    target._vm = subVm
+  }
 }
 
 /**

--- a/html5/default/vm/dom-helper.js
+++ b/html5/default/vm/dom-helper.js
@@ -193,6 +193,9 @@ export function removeTarget (vm, target, preserveBlock = false) {
   else {
     removeElement(target)
   }
+  if (target._vm) {
+    target._vm.$emit('hook:destroyed')
+  }
 }
 
 /**
@@ -235,4 +238,3 @@ function removeBlock (fragBlock, preserveBlock = false) {
     removeElement(fragBlock.end)
   }
 }
-


### PR DESCRIPTION
Add ability to emit `destroyed` event when using `if` `repeat` or `is` directive.

As described in PR #1104 