### PR TITLE
Update Doc chapter(spelling mistake)

### DIFF
--- a/doc/components/a.md
+++ b/doc/components/a.md
@@ -3,7 +3,7 @@
 <a href="https://github.com/weexteam/article/wiki/%E6%AC%A2%E8%BF%8E%E5%8F%82%E4%B8%8EWeex%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3%E7%BF%BB%E8%AF%91"  class="weex-translate incomplete">cn</a>
 
 ###Summary
-&lt;a&gt; defines a hyperlink to a page in the web. Its purpose and syntax is very simliar to [&lt;a&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in HTML5.
+&lt;a&gt; defines a hyperlink to a page in the web. Its purpose and syntax is very similar to [&lt;a&gt;](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in HTML5.
 
 ### Child Components
 

--- a/doc/components/special-element.md
+++ b/doc/components/special-element.md
@@ -4,7 +4,7 @@
 
 ## &lt;content&gt;
 
-The element serves as content distribution outlest in a composed component template. The element itself will be replaced.
+The element serves as content distribution outlet in a composed component template. The element itself will be replaced.
 
 alias: `<slot>`
 

--- a/doc/modules/clipboard.md
+++ b/doc/modules/clipboard.md
@@ -34,7 +34,7 @@ clipboard.getString(function(ret) {
 
 ### setString(text)
 
-set the text into clipboard, as the same as copy manully. 
+set the text into clipboard, as the same as copy manually. 
 
 #### Arguments
 

--- a/doc/modules/storage.md
+++ b/doc/modules/storage.md
@@ -24,7 +24,7 @@ or update that key's value if it already exists.
 ```js
 var storage = require('@weex-module/storage');
 storage.setItem('bar', 'bar-value', function(e) {
-  // callback.'e' is an object that contains 'result' and 'data'. e.result indicate wether `setItem` is succeed.
+  // callback.'e' is an object that contains 'result' and 'data'. e.result indicate whether `setItem` is succeed.
   // e.data will return 'undefined' if success or 'invalid_param' if your key/value is ""/null.
 });
 ```

--- a/doc/references/text-style.md
+++ b/doc/references/text-style.md
@@ -12,7 +12,7 @@ Text alike components share some common style rules. The text alike components c
 - `font-weight`: &lt;enum&gt; `normal` | `bold`. This property specifies the boldness of the font. Default value is `normal`.
 - `text-decoration`: &lt;enum&gt; `none` | `underline` | `line-through`. This property is used to set the text formatting to underline or line-through. The default value is `none`.
 - `text-align`: &lt;enum&gt; `left` | `center` | `right`. This property describes how inline content like text is aligned in its parent component. The default value is `left`.
-- `font-family`:&lt;string&gt; this property set the font-family of the text. This property **doesn't guarteen** the given font will always be set to the text. If the specified font cannot be found at the device, a typeface fallback will occurr and the default typeface will be load. The fallback mechanism may vary in different devices.
+- `font-family`:&lt;string&gt; this property set the font-family of the text. This property **doesn't guarantee** the given font will always be set to the text. If the specified font cannot be found at the device, a typeface fallback will occur and the default typeface will be load. The fallback mechanism may vary in different devices.
 - `text-overflow`:&lt;string&gt; `clip` | `ellipsis`. This property determines how overflowed content that is not displayed is signaled to users. It can be clipped, display an ellipsis.  
 
 The property `color` support multiple fomats of values, contains rgb, rgba, #fff, #ffffff, named-color.


### PR DESCRIPTION
The "This property doesn't  **guarteen** the given font will always be set to the text. If the specified font cannot be found at the device, a typeface fallback will **occurr** and the default typeface will be load." has two spelling mistake,should be

>  "guarteen" to "**guarantee**",

> "occurr" to "**occur**".

In the special-element.md,should be
> "outlest " to "**outlet**".