### PR TITLE
html5 fix img lazyload

### DIFF
--- a/html5/browser/base/component/lazyload.js
+++ b/html5/browser/base/component/lazyload.js
@@ -8,7 +8,7 @@ let lazyloadTimer
 
 // fire lazyimg on images.
 function fire () {
-  lib.img.fire()
+  setTimeout(() => lib.img.fire(), 0)
 }
 
 // we don't know when all images are appended


### PR DESCRIPTION
In the method `makeImageLazy`, the lazyload firing  is processed immediately. It should be delayed to the next tick since the dom is not ready yet. This should fix the bug that the last image in a repeat list is missing.