### PR TITLE
* [jsfm] fix bug: event will not be registered to document if the "ap…

### DIFF
--- a/html5/vdom/index.js
+++ b/html5/vdom/index.js
@@ -84,7 +84,8 @@ function appendBody (doc, node, before) {
     if (node.role === 'body') {
       node.docId = doc.id
       node.ownerDocument = doc
-      node.parentNode = documentElement
+      linkParent(node, documentElement)
+      delete doc.nodeMap[node.nodeId]
     }
     else {
       node.children.forEach(child => {


### PR DESCRIPTION
reproduce： weex/examples/component/scroller-demo.js

reproduce method： pull up the list at the end，the loading component will not be hidden, because the loading event does not be invoked

root cause: when creating the virtual DOM tree, if the root container's "append" attribute is "tree", the whole page will be create first and then be added to the document, which means that the docId will be assigned to the root container at last, while all of its children nodes can not get the docId when they are being created. A node couldn't be added to the "nodemap" of document if it do not have the docId.  If an event is passed from native, the current document cannot find the proper component to handle it, because its "nodemap" is empty.  

```javascript
function compileNativeComponent(vm, template, dest, type) {
.......
const treeMode = template.append === 'tree'
  const app = vm._app || {}
  if (app.lastSignal !== -1 && !treeMode) {
    console.debug('[JS Framework] compile to append single node for', element)
    app.lastSignal = attachTarget(vm, element, dest)
  }
  if (app.lastSignal !== -1) {
    compileChildren(vm, template, element)
  }
  if (app.lastSignal !== -1 && treeMode) {
    console.debug('[JS Framework] compile to append whole tree for', element)
    app.lastSignal = attachTarget(vm, element, dest)
  }
}
```