### PR TITLE
The relative path of the link of the README file in doc folder is wrong

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,9 +1,9 @@
 # Weex
 
 Table of Contents
-* [Tutorial](/tutorial.md)
-* [Syntax](/syntax/main.md)
-* [References](/references/bootstrap.md)
-* [Examples](/demo/hello-world.md)
-* [Service & Tools](/tools/cli.md)
+* [Tutorial](./tutorial.md)
+* [Syntax](./syntax/main.md)
+* [References](./references/bootstrap.md)
+* [Examples](./demo/hello-world.md)
+* [Service & Tools](./tools/cli.md)
 


### PR DESCRIPTION
Fix the 404 problem of accessing the links of README file. The relative path is wrong.