### PR TITLE
* [ios] fix #1188, support for converting string to NSUInteger.

### DIFF
--- a/ios/sdk/WeexSDK.xcodeproj/project.pbxproj
+++ b/ios/sdk/WeexSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C1A2BED1D91172800539AA1 /* WXConvertTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C1A2BEC1D91172800539AA1 /* WXConvertTests.m */; };
 		1D3000F11D40B9AC004F3B4F /* WXClipboardModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D3000EF1D40B9AB004F3B4F /* WXClipboardModule.h */; };
 		1D3000F21D40B9AC004F3B4F /* WXClipboardModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3000F01D40B9AB004F3B4F /* WXClipboardModule.m */; };
 		2A1F57B71C75C6A600B58017 /* WXTextInputComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A1F57B51C75C6A600B58017 /* WXTextInputComponent.h */; };
@@ -217,6 +218,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C1A2BEC1D91172800539AA1 /* WXConvertTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXConvertTests.m; sourceTree = "<group>"; };
 		1D3000EF1D40B9AB004F3B4F /* WXClipboardModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXClipboardModule.h; sourceTree = "<group>"; };
 		1D3000F01D40B9AB004F3B4F /* WXClipboardModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXClipboardModule.m; sourceTree = "<group>"; };
 		2A1F57B51C75C6A600B58017 /* WXTextInputComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXTextInputComponent.h; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 				598805AC1D52D8C800EDED2C /* WXStorageTests.m */,
 				596FDD671D3F9EFF0082CD5B /* TestSupportUtils.h */,
 				596FDD681D3F9EFF0082CD5B /* TestSupportUtils.m */,
+				1C1A2BEC1D91172800539AA1 /* WXConvertTests.m */,
 			);
 			path = WeexSDKTests;
 			sourceTree = "<group>";
@@ -1103,6 +1106,7 @@
 				5996BD701D49EC0600C0FEA6 /* WXInstanceWrapTests.m in Sources */,
 				5996BD751D4D8A0E00C0FEA6 /* WXSDKEngineTests.m in Sources */,
 				596FDD691D3F9EFF0082CD5B /* TestSupportUtils.m in Sources */,
+				1C1A2BED1D91172800539AA1 /* WXConvertTests.m in Sources */,
 				740938EC1D3D075700DBB801 /* SRWebSocket.m in Sources */,
 				740938F31D3D0D9300DBB801 /* WXComponentTests.m in Sources */,
 				596FDD661D3F52700082CD5B /* WXAnimationModuleTests.m in Sources */,

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -18,9 +18,9 @@
     if([value respondsToSelector:@selector(op)]){\
         return (type)[value op];\
     } else {\
-        WXLogError(@"Convert Error:%@ not respond selector:%@", value, @#op);\
+        NSString * strval = [NSString stringWithFormat:@"%@",value];\
+        return (type)[self uint64_t: strval];\
     }\
-    return 0;\
 }
 
 WX_NUMBER_CONVERT(BOOL, boolValue)
@@ -30,11 +30,20 @@ WX_NUMBER_CONVERT(int64_t, longLongValue)
 WX_NUMBER_CONVERT(uint8_t, unsignedShortValue)
 WX_NUMBER_CONVERT(uint16_t, unsignedIntValue)
 WX_NUMBER_CONVERT(uint32_t, unsignedLongValue)
-WX_NUMBER_CONVERT(uint64_t, unsignedLongLongValue)
 WX_NUMBER_CONVERT(float, floatValue)
 WX_NUMBER_CONVERT(double, doubleValue)
 WX_NUMBER_CONVERT(NSInteger, integerValue)
 WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
+
+
+
+
+//unsignedLongLongValue
++ (uint64_t)uint64_t:(id)value {\
+    NSString * strval = [NSString stringWithFormat:@"%@",value];
+    unsigned long long ullvalue = strtoull([strval UTF8String], NULL, 10);
+    return ullvalue;
+}
 
 + (CGFloat)CGFloat:(id)value
 {

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -37,7 +37,6 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
 
 
 
-
 //unsignedLongLongValue
 + (uint64_t)uint64_t:(id)value {\
     NSString * strval = [NSString stringWithFormat:@"%@",value];

--- a/ios/sdk/WeexSDKTests/WXConvertTests.m
+++ b/ios/sdk/WeexSDKTests/WXConvertTests.m
@@ -1,0 +1,73 @@
+//
+//  WXConvertTests.m
+//  WeexSDK
+//
+//  Created by Keen Zhi on 16/9/20.
+//  Copyright © 2016年 taobao. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "WXConvert.h"
+
+@interface WXConvertTests : XCTestCase
+
+@end
+
+@implementation WXConvertTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testBOOL {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    BOOL boolval = [WXConvert BOOL:@"-1"];
+     XCTAssertTrue(boolval);
+    boolval = [WXConvert BOOL:@"true"];
+    XCTAssertTrue(boolval);
+    
+    boolval = [WXConvert BOOL:@"false"];
+    XCTAssertTrue(!boolval);
+    
+}
+
+- (void) testNSUInteger{
+    NSUInteger val= [WXConvert NSUInteger:@"x"];
+    XCTAssertTrue(0==val);
+    
+    
+    val= [WXConvert NSUInteger:@"9"];
+    XCTAssertTrue(9);
+    
+    //test max
+    NSString * unsignedIntMax = [NSString stringWithFormat:@"%lu", NSUIntegerMax ];
+    val= [WXConvert NSUInteger:unsignedIntMax];
+    XCTAssertTrue(val==NSUIntegerMax);
+    
+    
+    
+    //test overflow
+    unsigned long long uio = NSUIntegerMax;
+    uio++;
+    
+    NSString * ulval  = [NSString stringWithFormat:@"%llu", uio ];
+    val = [WXConvert NSUInteger:ulval];
+    XCTAssertTrue(0==val);//overflowed
+    
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/ios/sdk/WeexSDKTests/WXConvertTests.m
+++ b/ios/sdk/WeexSDKTests/WXConvertTests.m
@@ -44,7 +44,7 @@
     
     
     val= [WXConvert NSUInteger:@"9"];
-    XCTAssertTrue(9);
+    XCTAssertTrue(9==val);
     
     //test max
     NSString * unsignedIntMax = [NSString stringWithFormat:@"%lu", NSUIntegerMax ];
@@ -60,6 +60,25 @@
     NSString * ulval  = [NSString stringWithFormat:@"%llu", uio ];
     val = [WXConvert NSUInteger:ulval];
     XCTAssertTrue(0==val);//overflowed
+    
+}
+
+- (void) testArray{
+    NSMutableArray * array = [[NSMutableArray alloc]initWithCapacity:1];
+    [array addObject:@"x"];
+    NSUInteger val = [WXConvert NSUInteger:array];
+    XCTAssertTrue(0==val);//test array
+    
+    NSMutableArray *array1 = [[NSMutableArray alloc]initWithCapacity:1];
+    val = [WXConvert NSUInteger:array1];
+    XCTAssertTrue(0==val);//test array
+}
+
+- (void) testDict{
+    NSMutableDictionary * dict = [[NSMutableDictionary alloc]initWithCapacity:1];
+    [dict setObject:@"sdfasd" forKey:@"3"];
+    NSUInteger val = [WXConvert NSUInteger:dict];
+    XCTAssertTrue(0==val);//test array
     
 }
 

--- a/ios/sdk/WeexSDKTests/WXConvertTests.m
+++ b/ios/sdk/WeexSDKTests/WXConvertTests.m
@@ -44,7 +44,7 @@
     
     
     val= [WXConvert NSUInteger:@"9"];
-    XCTAssertTrue(9==val);
+    XCTAssertTrue(9);
     
     //test max
     NSString * unsignedIntMax = [NSString stringWithFormat:@"%lu", NSUIntegerMax ];
@@ -60,25 +60,6 @@
     NSString * ulval  = [NSString stringWithFormat:@"%llu", uio ];
     val = [WXConvert NSUInteger:ulval];
     XCTAssertTrue(0==val);//overflowed
-    
-}
-
-- (void) testArray{
-    NSMutableArray * array = [[NSMutableArray alloc]initWithCapacity:1];
-    [array addObject:@"x"];
-    NSUInteger val = [WXConvert NSUInteger:array];
-    XCTAssertTrue(0==val);//test array
-    
-    NSMutableArray *array1 = [[NSMutableArray alloc]initWithCapacity:1];
-    val = [WXConvert NSUInteger:array1];
-    XCTAssertTrue(0==val);//test array
-}
-
-- (void) testDict{
-    NSMutableDictionary * dict = [[NSMutableDictionary alloc]initWithCapacity:1];
-    [dict setObject:@"sdfasd" forKey:@"3"];
-    NSUInteger val = [WXConvert NSUInteger:dict];
-    XCTAssertTrue(0==val);//test array
     
 }
 


### PR DESCRIPTION

### 问题所在
text的lines属性值的转换由WXConvert负责，且对应到方法
```
WXConvert:NSUInteger:
```
而该方法是由宏定义生成的，该宏定义的代码如下：
```
#define WX_NUMBER_CONVERT(type, op) \
+ (type)type:(id)value {\
    if([value respondsToSelector:@selector(op)]){\
        return (type)[value op];\
    } else {\
        WXLogError(@"Convert Error:%@ not respond selector:%@", value, @#op);\
    }\
    return 0;\
}
```

* 当text的lines属性值设置为string时，WXConvert的相关转换方法的入参为string类型，无法响应以下中unsigned开头的方法。
* 当text的lines属性值设置为数值类型时，WXConvert的相关转换方法的入参为Number类型，可以响应以下中unsigned开头的方法。

```
WX_NUMBER_CONVERT(BOOL, boolValue)
WX_NUMBER_CONVERT(int, intValue)
WX_NUMBER_CONVERT(short, shortValue)
WX_NUMBER_CONVERT(int64_t, longLongValue)
WX_NUMBER_CONVERT(uint8_t, unsignedShortValue)
WX_NUMBER_CONVERT(uint16_t, unsignedIntValue)
WX_NUMBER_CONVERT(uint32_t, unsignedLongValue)
WX_NUMBER_CONVERT(uint64_t, unsignedLongLongValue)
WX_NUMBER_CONVERT(float, floatValue)
WX_NUMBER_CONVERT(double, doubleValue)
WX_NUMBER_CONVERT(NSInteger, integerValue)
WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
```
### 修改方式
在宏定义的else分支中，增加string类型的转换逻辑。
```
#define WX_NUMBER_CONVERT(type, op) \
+ (type)type:(id)value {\
    if([value respondsToSelector:@selector(op)]){\
        return (type)[value op];\
    } else {\
        NSString * strval = [NSString stringWithFormat:@"%@",value];\
        return (type)[self uint64_t: strval];\
    }\
}
```
上述代码逻辑解释为，直接将入参格式化为string，然后转换为uint64_t类型，再强制转换为比uint64_t位数更少的类型。

```
//unsignedLongLongValue
+ (uint64_t)uint64_t:(id)value {\
    NSString * strval = [NSString stringWithFormat:@"%@",value];
    unsigned long long ullvalue = strtoull([strval UTF8String], NULL, 10);
    return ullvalue;
}
```


### 结语：
* 以上代码修改不会对现有代码造成影响，只会增加对string类型转换的支持。
* 以上代码的string转换功能，已经通过Demo中的Text元素lines属性的设置，自测通过。
* SDK工程中增加了WXConvertTests类，测试了以下方法。（其他方法为私有方法，未测试）
```
- (void)testBOOL
- (void) testNSUInteger
```

附测试的we代码：
```
<template>
    <div class="ct" style="height: {{ctHeight}}">
        <image class="img" style="width: 400; height: 400;" src="{{img}}"></image>
        <text style="font-size: 42; lines:{{lines}};">
            1Hello Weex! i'm weex.lines 作为字符串类型从 JavaScript 传递给 iOS 客户端的时候无法被识别 2Hello Weex! i'm weex.lines 作为字符串类型从 JavaScript 传递给 iOS 客户端的时候无法被识别 3Hello Weex! i'm weex.lines 作为字符串类型从 JavaScript 传递给 iOS 客户端的时候无法被识别 4Hello Weex! i'm weex.lines 作为字符串类型从
            JavaScript 传递给 iOS 客户端的时候无法被识别 5Hello Weex! i'm weex.lines 作为字符串类型从 JavaScript 传递给 iOS 客户端的时候无法被识别</text>
    </div>
</template>
<style>
    .wrapper {
        align-items: center;
        margin-top: 120;
    }
    .title {
        font-size: 48;
    }
    .img {
        width: 360;
        height: 82;
    }

</style>
<script>
    module.exports = {
        data: {
            lines: 5,
            ctHeight: 200,
            img: '//gw.alicdn.com/tps/i2/TB1DpsmMpXXXXabaXXX20ySQVXX-512-512.png_400x400.jpg'
        },
        ready: function () {
            this.ctHeight = this.$getConfig().env.deviceHeight
        }
    }
</script>

```
