### PR TITLE
* [jsfm] fix #1237   fix binding event bug of components which have '…

### DIFF
--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -254,7 +254,7 @@ function bindEvents (vm, el, events) {
         console.debug(`[JS Framework] The method "${handler}" is not defined.`)
       }
     }
-    const realVm = vm._realParent?vm._realParent:vm;
+    const realVm = vm._realParent ? vm._realParent : vm
     setEvent(realVm, el, key, handler)
   }
 }

--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -254,7 +254,6 @@ function bindEvents (vm, el, events) {
         console.debug(`[JS Framework] The method "${handler}" is not defined.`)
       }
     }
-    
     const realVm = vm._realParent ? vm._realParent : vm
     setEvent(realVm, el, key, handler)
   }

--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -254,7 +254,7 @@ function bindEvents (vm, el, events) {
         console.debug(`[JS Framework] The method "${handler}" is not defined.`)
       }
     }
-    var realVm = vm._realParent?vm._realParent:vm;
+    const realVm = vm._realParent?vm._realParent:vm;
     setEvent(realVm, el, key, handler)
   }
 }

--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -254,7 +254,8 @@ function bindEvents (vm, el, events) {
         console.debug(`[JS Framework] The method "${handler}" is not defined.`)
       }
     }
-    setEvent(vm, el, key, handler)
+    var realVm = vm._realParent?vm._realParent:vm;
+    setEvent(realVm, el, key, handler)
   }
 }
 

--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -254,6 +254,7 @@ function bindEvents (vm, el, events) {
         console.debug(`[JS Framework] The method "${handler}" is not defined.`)
       }
     }
+    
     const realVm = vm._realParent ? vm._realParent : vm
     setEvent(realVm, el, key, handler)
   }

--- a/html5/test/unit/default/vm/events.js
+++ b/html5/test/unit/default/vm/events.js
@@ -59,7 +59,6 @@ describe('bind and fire events', () => {
 
     checkReady(vm, function () {
       doc.close()
-
       expect(doc.body.event.click).a('function')
 
       const el = doc.body
@@ -75,6 +74,61 @@ describe('bind and fire events', () => {
         { module: 'dom', method: 'updateAttrs', args: [el.ref, { a: 2 }] }
       ])
 
+      done()
+    })
+  })
+
+  it('context of event binding to element width repeat attribute', (done) => {
+    customComponentMap.foo = {
+      template: {
+        type: 'div',
+        id: 'container',
+        events: {
+          click: 'containerClick'
+        },
+        children: [
+          {
+            type: 'div',
+            id: 'items',
+            'repeat': function () { return this.items },
+            events: {
+              click: 'itemsClick'
+            },
+            children: [
+              {
+                type: 'div'
+              }
+            ]
+          }
+        ]
+      },
+      data: function () {
+        return {
+          items: [
+              { name: 1 },
+              { name: 2 }
+          ]
+        }
+      },
+      methods: {
+        containerClick: function () {
+          expect(this).eql(vm)
+        },
+        itemsClick: function () {
+          expect(this).eql(vm)
+        }
+      }
+    }
+
+    const app = { doc, customComponentMap }
+    const vm = new Vm('foo', customComponentMap.foo, { _app: app })
+
+    checkReady(vm, function () {
+      doc.close()
+      const containerEl = vm.$el('container')
+      const itemsEl = vm.$el('items')
+      containerEl.event.click()
+      itemsEl.event.click()
       done()
     })
   })


### PR DESCRIPTION
这个问题的原因是， 在使用`repeat`属性的标签和不使用`repeat`属性的标签上绑定事件，事件处理涵数的上下文并不相同，即`this`指向的并不是同一个对象。

demo
```vue
  <template>
    <div  onclick={{onClick1}}>
      <div repeat={{items}} onclick={{onClick2}}>
        <div class="item">
          <text class="text1" onclick={{onClick3}}> {{name}}</text>
        </div>
      </div>
    </div>
</template>

<script>
  module.exports = {
    data:{
      items:[{name:1},{name:2}]
    },
    methods:{
      onClick1:function(){
         //this是当前组件上下文
         console.log(this)
      },
      onClick2:function(){
         //this是repeat上下文
        console.log(this)
      },
      onClick3:function(){
         //this是repeat上下文
        console.log(this)
      }
    }

  }

</script>
 
```


在weex编译带有 `repeat` 属性模板的时候，用当前组件的上下文创建了一个新的上下文。

```javascript

function mergeContext (context, mergedData) {
  const newContext = Object.create(context)
  newContext._data = mergedData
  initData(newContext)
  initComputed(newContext)
  newContext._realParent = context
  return newContext
}


```
这样做的意义在于，能够在新的上下文中增加数据，而又不影响当前的组件上下文。但这样在绑定事件的时候上下文就不一致了   

原有绑定事件的实现
```javascript

function bindEvents (vm, el, events) {
  if (!events) {
    return
  }
  const keys = Object.keys(events)
  let i = keys.length
  while (i--) {
    const key = keys[i]
    let handler = events[key]
    if (typeof handler === 'string') {
      handler = vm[handler]
      /* istanbul ignore if */
      if (!handler) {
        console.debug(`[JS Framework] The method "${handler}" is not defined.`)
      }
    }
    setEvent(vm, el, key, handler)
  }
}

```


修改方案：将上下文重置为当前组件上下文

```javascript

function bindEvents (vm, el, events) {
  if (!events) {
    return
  }
  const keys = Object.keys(events)
  let i = keys.length
  while (i--) {
    const key = keys[i]
    let handler = events[key]
    if (typeof handler === 'string') {
      handler = vm[handler]
      /* istanbul ignore if */
      if (!handler) {
        console.debug(`[JS Framework] The method "${handler}" is not defined.`)
      }
    }
    // 获取真正的下下文
    var realVm = vm._realParent?vm._realParent:vm;
    setEvent(realVm, el, key, handler)
  }
}

```







