### PR TITLE
html5 fix class name

### DIFF
--- a/html5/browser/extend/components/image/index.js
+++ b/html5/browser/extend/components/image/index.js
@@ -15,7 +15,8 @@ const DEFAULT_RESIZE_MODE = 'stretch'
 const proto = {
   create () {
     const node = document.createElement('div')
-    node.classList.add('weex-img', 'weex-element')
+    node.classList.add('weex-img')
+    node.classList.add('weex-element')
     return node
   },
 

--- a/html5/browser/extend/components/scrollable/loading/index.js
+++ b/html5/browser/extend/components/scrollable/loading/index.js
@@ -34,7 +34,8 @@ function hide (loading) {
 const proto = {
   create () {
     const node = document.createElement('div')
-    node.classList.add('weex-container', 'weex-loading')
+    node.classList.add('weex-container')
+    node.classList.add('weex-loading')
     return node
   },
 

--- a/html5/browser/extend/components/scrollable/refresh/index.js
+++ b/html5/browser/extend/components/scrollable/refresh/index.js
@@ -41,7 +41,8 @@ function hide (refresh) {
 const proto = {
   create () {
     const node = document.createElement('div')
-    node.classList.add('weex-container', 'weex-refresh')
+    node.classList.add('weex-container')
+    node.classList.add('weex-refresh')
     return node
   },
 

--- a/html5/browser/extend/components/scrollable/scrollable.js
+++ b/html5/browser/extend/components/scrollable/scrollable.js
@@ -47,13 +47,12 @@ function getProto (Weex) {
   function create (nodeType) {
     const Scroll = lib.scroll
     const node = Component.prototype.create.call(this, nodeType)
-    node.classList.add('weex-container', 'scrollable-wrap')
+    node.classList.add('weex-container')
+    node.classList.add('scrollable-wrap')
     this.scrollElement = document.createElement('div')
-    this.scrollElement.classList.add(
-      'weex-container',
-      'scrollable-element',
-      'dir-' + this.direction
-    )
+    this.scrollElement.classList.add('weex-container')
+    this.scrollElement.classList.add('scrollable-element')
+    this.scrollElement.classList.add('dir-' + this.direction)
 
     this.scrollElement.style.webkitBoxOrient = directionMap[this.direction][1]
     this.scrollElement.style.webkitFlexDirection = directionMap[this.direction][0]

--- a/html5/browser/extend/components/spinner/index.js
+++ b/html5/browser/extend/components/spinner/index.js
@@ -90,9 +90,11 @@ function computeKeyFrameRules (rgb) {
 const proto = {
   create () {
     const node = document.createElement('div')
-    node.classList.add('weex-container', 'weex-spinner-wrap')
+    node.classList.add('weex-container')
+    node.classList.add('weex-spinner-wrap')
     this.spinner = document.createElement('div')
-    this.spinner.classList.add('weex-element', 'weex-spinner')
+    this.spinner.classList.add('weex-element')
+    this.spinner.classList.add('weex-spinner')
     node.appendChild(this.spinner)
     return node
   }

--- a/html5/browser/extend/components/textarea.js
+++ b/html5/browser/extend/components/textarea.js
@@ -12,7 +12,8 @@ const DEFAULT_ROWS = 2
 const proto = {
   create () {
     const node = document.createElement('textarea')
-    node.classList.add('weex-element', 'weex-textarea')
+    node.classList.add('weex-element')
+    node.classList.add('weex-textarea')
     return node
   }
 }

--- a/html5/browser/extend/components/video/index.js
+++ b/html5/browser/extend/components/video/index.js
@@ -7,7 +7,8 @@ function getProto (Weex) {
   return {
     create () {
       const node = document.createElement('video')
-      node.classList.add('weex-video', 'weex-element')
+      node.classList.add('weex-video')
+      node.classList.add('weex-element')
       node.controls = true
       node.autoplay = this.autoPlay
       node.setAttribute('play-status', this.playStatus)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:test": "webpack --config build/webpack.test.config.js",
     "dist:browser": "npm run build:browser && npm run build:common && bash ./bin/dist-browser.sh",
     "dist": "npm run dist:browser",
-    "dev:browser": "webpack --watch --config build/webpack.browser.config.js",
+    "dev:browser": "wwp && webpack --watch --config build/webpack.browser.config.js",
     "dev:native": "webpack --watch --config build/webpack.native.config.js",
     "dev:examples": "webpack --watch --config build/webpack.examples.config.js",
     "dev:test": "webpack --watch --config build/webpack.test.config.js",


### PR DESCRIPTION
Adding multiple class names through `classList.add()` is not supported for some browsers. For examples: `element.classList.add('weex-ct', 'weex-element')` is only adding `weex-ct` to the element. For now this bug is discovered on android UC browser only (including the latest `v11.xxx` version).