### PR TITLE
[ios] bugfix - url : 打开url的时候需要先判断一下有没有参数，以决定拼接random参数是用？还是&连接

### DIFF
--- a/ios/playground/WeexDemo/WXDemoViewController.m
+++ b/ios/playground/WeexDemo/WXDemoViewController.m
@@ -134,7 +134,7 @@
         return;
     }
     NSURL *URL = [self testURL: [self.url absoluteString]];
-    NSString *randomURL = [NSString stringWithFormat:@"%@?random=%d",URL.absoluteString,arc4random()];
+    NSString *randomURL = [NSString stringWithFormat:@"%@%@random=%d",URL.absoluteString,URL.query?@"&":@"?",arc4random()];
     [_instance renderWithURL:[NSURL URLWithString:randomURL] options:@{@"bundleUrl":URL.absoluteString} data:nil];
 }
 


### PR DESCRIPTION
打开url的时候需要先判断一下有没有参数，以决定拼接random参数是用？还是&连接，要不然url会拼错