### PR TITLE
[jsfm] supported framework flag in the beginning of a JS bundle but…

### DIFF
--- a/dist/weex-js-framework/package.json
+++ b/dist/weex-js-framework/package.json
@@ -1,8 +1,8 @@
 {
   "name": "weex-js-framework",
-  "version": "0.16.12",
+  "version": "0.16.14",
   "subversion": {
-    "framework": "0.16.12",
+    "framework": "0.16.14",
     "transformer": ">=0.1.5 <0.4"
   },
   "description": "Weex JS Framework",
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "core-js": "^2.4.0",
-    "semver": "^5.1.0"
+    "semver": "^5.1.0",
+    "weex-rx-framework": "0.1.13"
   }
 }

--- a/html5/runtime/init.js
+++ b/html5/runtime/init.js
@@ -1,6 +1,6 @@
 let frameworks
 
-const versionRegExp = /^\/\/ *(\{[^\}]*\}) *\r?\n/
+const versionRegExp = /^\s*\/\/ *(\{[^\}]*\}) *\r?\n/
 
 /**
  * Detect a JS Bundle code and make sure which framework it's based to. Each JS

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "subversion": {
     "browser": "0.3.0",
-    "framework": "0.16.12",
+    "framework": "0.16.14",
     "transformer": ">=0.1.5 <0.4"
   },
   "dependencies": {


### PR DESCRIPTION
Supported framework flag in the beginning of a JS bundle but after some spaces/linebreaks

----

```javascript
// { "framework": "xxx" }
'something else'
```

works for xxx

----

```javascript
//{framework:'xxx'}
'something else'
```

works for xxx

----

```javascript


        // { framework: 'xxx' }
'something else'
```

works for xxx

----

```javascript
'something else'
// { "framework": "xxx" }
'something else'
```

not work for xxx, just work for default framework

----

```javascript
'something else'
```

just work for default framework
