### PR TITLE
add iOS support bundle image & fix issue about WXConvert 's UIColor method

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -165,7 +165,7 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
         colorCache.countLimit = 64;
     });
     
-    if ([value isKindOfClass:[NSNull class]]) {
+    if ([value isKindOfClass:[NSNull class]] || !value) {
         return nil;
     }
     


### PR DESCRIPTION
image组件在iOS一方面增加支持本地图片，src中输入iOS工程里面存在的image名字即可，如下

```
<image style="width: 100;height: 100;" src="scan"></image>
```
在WXImageComponent内会自动区别是网络图片还是本地图片

同时，看看有没有可能android和web支持相应功能