### PR TITLE
[html5] add getComponentRect api for dom module

### DIFF
--- a/html5/render/browser/extend/api/dom.js
+++ b/html5/render/browser/extend/api/dom.js
@@ -35,7 +35,7 @@ const dom = {
   /**
    * getComponentRect
    * @param {string} ref
-   * @param {string} callbackId
+   * @param {function} callbackId
    */
   getComponentRect: function (ref, callbackId) {
     const info = { result: false }
@@ -91,7 +91,7 @@ const meta = {
     args: ['string', 'object']
   }, {
     name: 'getComponentRect',
-    args: ['string', 'string']
+    args: ['string', 'function']
   }, {
     name: 'addRule',
     args: ['string', 'object']

--- a/html5/render/browser/extend/api/dom.js
+++ b/html5/render/browser/extend/api/dom.js
@@ -33,6 +33,41 @@ const dom = {
   },
 
   /**
+   * getComponentRect
+   * @param {string} ref
+   * @param {string} callbackId
+   */
+  getComponentRect: function (ref, callbackId) {
+    const info = { result: false }
+
+    if (ref && ref === 'viewport') {
+      info.result = true
+      info.size = {
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight,
+        top: 0,
+        left: 0,
+        right: document.documentElement.clientWidth,
+        bottom: document.documentElement.clientHeight
+      }
+    }
+    else {
+      const elem = this.getComponentManager().getComponent(ref)
+      if (elem && elem.node) {
+        info.result = true
+        info.size = elem.node.getBoundingClientRect()
+      }
+    }
+
+    const message = info.result ? info : {
+      result: false,
+      errMsg: 'Illegal parameter'
+    }
+    this.sender.performCallback(callbackId, message)
+    return message
+  },
+
+  /**
    * for adding fontFace
    * @param {string} key fontFace
    * @param {object} styles rules
@@ -54,6 +89,9 @@ const meta = {
   dom: [{
     name: 'scrollToElement',
     args: ['string', 'object']
+  }, {
+    name: 'getComponentRect',
+    args: ['string', 'string']
   }, {
     name: 'addRule',
     args: ['string', 'object']


### PR DESCRIPTION
Usage :

```js
var dom = require('@weex-module/dom')
module.exports = {
  ready: function() {
    var elem = this.$el('elementId')
    dom.getComponentRect(elem, function(info) {

      // got the component layout information
      console.log(info)
      
    })
  }
}
```

Data structure of `info` :

```js
// success
{
  result: true,
  size: {
    width  : Number
    height : Number,
    top    : Number, // distance from component top edge to the top of viewport
    left   : Number, // distance from component left edge to the left of viewport
    right  : Number, // distance from component right edge to the left of viewport
    bottom : Number, // distance from component bottom edge to the top of viewport
  }
}

// fail
{
  result: false,
  errMsg: 'Illegal parameter'
}
```
