### PR TITLE
* [ios] fix issue about WXConvert 's UIColor method

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -173,7 +173,7 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
         colorCache.countLimit = 64;
     });
     
-    if ([value isKindOfClass:[NSNull class]]) {
+    if ([value isKindOfClass:[NSNull class]] || !value) {
         return nil;
     }
     


### PR DESCRIPTION
第二个commit是

```
+ (UIColor *)UIColor:(id)value
```
value为nil时，
会返回如下color

```
    color = [UIColor colorWithRed:255 green:255 blue:255 alpha:1.0];

```

但应该是要返回nil的