### PR TITLE
* [jsfm] fix #1447, fix binding event bug of components which have re…

### DIFF
--- a/html5/default/vm/directive.js
+++ b/html5/default/vm/directive.js
@@ -287,8 +287,7 @@ function bindEvents (vm, el, events) {
         console.debug(`[JS Framework] The method "${handler}" is not defined.`)
       }
     }
-    const realVm = vm._realParent ? vm._realParent : vm
-    setEvent(realVm, el, key, handler)
+    setEvent(vm, el, key, handler)
   }
 }
 

--- a/html5/test/unit/default/vm/events.js
+++ b/html5/test/unit/default/vm/events.js
@@ -79,61 +79,6 @@ describe('bind and fire events', () => {
     })
   })
 
-  it('context of event binding to element width repeat attribute', (done) => {
-    customComponentMap.foo = {
-      template: {
-        type: 'div',
-        id: 'container',
-        events: {
-          click: 'containerClick'
-        },
-        children: [
-          {
-            type: 'div',
-            id: 'items',
-            'repeat': function () { return this.items },
-            events: {
-              click: 'itemsClick'
-            },
-            children: [
-              {
-                type: 'div'
-              }
-            ]
-          }
-        ]
-      },
-      data: function () {
-        return {
-          items: [
-              { name: 1 },
-              { name: 2 }
-          ]
-        }
-      },
-      methods: {
-        containerClick: function () {
-          expect(this).eql(vm)
-        },
-        itemsClick: function () {
-          expect(this).eql(vm)
-        }
-      }
-    }
-
-    const app = { doc, customComponentMap }
-    const vm = new Vm('foo', customComponentMap.foo, { _app: app })
-
-    checkReady(vm, function () {
-      doc.close()
-      const containerEl = vm.$el('container')
-      const itemsEl = vm.$el('items')
-      containerEl.event.click()
-      itemsEl.event.click()
-      done()
-    })
-  })
-
   it('emit, broadcast and dispatch vm events', (done) => {
     customComponentMap.foo = {
       template: {


### PR DESCRIPTION
https://github.com/alibaba/weex/pull/1284 这个pr修复 `repeat` 内添加事件上下文不一致的情况，但同时导致了 ` repeat ` 内的事件获取不到数据的情况。

这里有一个矛盾， 保持上下文一致或者不一致都有问题。综合考虑之后的解决方案：
 - 保持原有设计， 些问题可以修复
 - 如果用户发现上下文不一致，可以能过 `this._realParent` 获取真正的上下文。 