### PR TITLE
* [all] add missing shebang

### DIFF
--- a/start
+++ b/start
@@ -1,3 +1,4 @@
+#!/bin/bash
 # called by native
 THIS_DIR=$(dirname "$0")
 pushd "$THIS_DIR"


### PR DESCRIPTION
Add missing shebang for `start`.

Run `./start` without shebang in `fish` shell got:

```
Failed to execute process './start'. Reason:
exec: Exec format error
The file './start' is marked as an executable but could not be run by the operating system.
```