### PR TITLE
* [html5] stream module  cors cookie support

### DIFF
--- a/html5/browser/extend/api/stream.js
+++ b/html5/browser/extend/api/stream.js
@@ -71,7 +71,7 @@ function _xhr (config, callback, progressCallback) {
 
   // cors cookie support
   if (config.withCrendentials === true) {
-    xhr.withCrendentials = true;
+    xhr.withCrendentials = true
   }
 
   const headers = config.headers || {}

--- a/html5/browser/extend/api/stream.js
+++ b/html5/browser/extend/api/stream.js
@@ -70,12 +70,11 @@ function _xhr (config, callback, progressCallback) {
   xhr.open(config.method, config.url, true)
 
   // cors cookie support
-  if (config.xhrFields){
-    for (let name in config.xhrFields){
+  if (config.xhrFields) {
+    for (const name in config.xhrFields) {
       xhr[name] = config.xhrFields[name]
     }
   }
-
 
   const headers = config.headers || {}
   for (const k in headers) {

--- a/html5/browser/extend/api/stream.js
+++ b/html5/browser/extend/api/stream.js
@@ -69,6 +69,14 @@ function _xhr (config, callback, progressCallback) {
   xhr.responseType = config.type
   xhr.open(config.method, config.url, true)
 
+  // cors cookie support
+  if (config.xhrFields){
+    for (let name in config.xhrFields){
+      xhr[name] = config.xhrFields[name]
+    }
+  }
+
+
   const headers = config.headers || {}
   for (const k in headers) {
     xhr.setRequestHeader(k, headers[k])
@@ -177,6 +185,7 @@ const stream = {
    *   - headers {obj}
    *   - url {string}
    *   - mode {string} 'cors' | 'no-cors' | 'same-origin' | 'navigate'
+   *   - xhrFields {obj}
    *   - body
    *   - type {string} 'json' | 'jsonp' | 'text'
    * @param  {string} callbackId

--- a/html5/browser/extend/api/stream.js
+++ b/html5/browser/extend/api/stream.js
@@ -70,10 +70,8 @@ function _xhr (config, callback, progressCallback) {
   xhr.open(config.method, config.url, true)
 
   // cors cookie support
-  if (config.xhrFields) {
-    for (const name in config.xhrFields) {
-      xhr[name] = config.xhrFields[name]
-    }
+  if (config.withCrendentials === true) {
+    xhr.withCrendentials = true;
   }
 
   const headers = config.headers || {}
@@ -184,7 +182,7 @@ const stream = {
    *   - headers {obj}
    *   - url {string}
    *   - mode {string} 'cors' | 'no-cors' | 'same-origin' | 'navigate'
-   *   - xhrFields {obj}
+   *   - withCrendentials {boolean}
    *   - body
    *   - type {string} 'json' | 'jsonp' | 'text'
    * @param  {string} callbackId


### PR DESCRIPTION
目前html5 中 stream module不支持在跨域cors情况下带cookie，目前不管zepto和jquery都有这个配置，希望可以加上，原生客户端不需要此配置，但是h5得场景下有需求，希望可以合进去，谢谢！

