### PR TITLE
bug fix.WXSQLiteOpenHelper mem leak

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
@@ -499,6 +499,8 @@ public class WXSDKInstance implements IWXActivityStateListener {
       options.put(BUNDLE_URL, url);
     }
 
+    mWXPerformance.templateUrl = url;
+
     Uri uri=Uri.parse(url);
     if(uri!=null && TextUtils.equals(uri.getScheme(),"file")){
       render(pageName, WXFileUtils.loadAsset(assembleFilePath(uri), mContext),options,jsonInitData,width,height,flag);

--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
@@ -499,8 +499,6 @@ public class WXSDKInstance implements IWXActivityStateListener {
       options.put(BUNDLE_URL, url);
     }
 
-    mWXPerformance.templateUrl = url;
-
     Uri uri=Uri.parse(url);
     if(uri!=null && TextUtils.equals(uri.getScheme(),"file")){
       render(pageName, WXFileUtils.loadAsset(assembleFilePath(uri), mContext),options,jsonInitData,width,height,flag);

--- a/android/sdk/src/main/java/com/taobao/weex/appfram/storage/DefaultWXStorage.java
+++ b/android/sdk/src/main/java/com/taobao/weex/appfram/storage/DefaultWXStorage.java
@@ -233,7 +233,7 @@ public class DefaultWXStorage implements IWXStorageAdapter {
     }
 
     public DefaultWXStorage(Context context) {
-        this.mDatabaseSupplier = WXSQLiteOpenHelper.getInstance(context);
+        this.mDatabaseSupplier = new WXSQLiteOpenHelper(context);
     }
 
 

--- a/android/sdk/src/main/java/com/taobao/weex/appfram/storage/WXSQLiteOpenHelper.java
+++ b/android/sdk/src/main/java/com/taobao/weex/appfram/storage/WXSQLiteOpenHelper.java
@@ -224,8 +224,6 @@ public class WXSQLiteOpenHelper extends SQLiteOpenHelper {
     static SimpleDateFormat sDateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
 
 
-    private static WXSQLiteOpenHelper sInstance;
-
     private Context mContext;
     private SQLiteDatabase mDb;
 
@@ -249,23 +247,12 @@ public class WXSQLiteOpenHelper extends SQLiteOpenHelper {
             + ")";
 
 
-    private WXSQLiteOpenHelper(Context context) {
+    public WXSQLiteOpenHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
         this.mContext = context;
     }
 
-    public static WXSQLiteOpenHelper getInstance(Context context) {
-        if (context == null) {
-            WXLogUtils.e(TAG_STORAGE,"can not get context instance...");
-            return null;
-        }
-        if (sInstance == null) {
-            sInstance = new WXSQLiteOpenHelper(context);
-        }
-        return sInstance;
-    }
-
-    SQLiteDatabase getDatabase() {
+    public SQLiteDatabase getDatabase() {
         ensureDatabase();
         return mDb;
     }

--- a/android/sdk/src/test/java/com/taobao/weex/appfram/storage/DefaultWXStorageTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/appfram/storage/DefaultWXStorageTest.java
@@ -205,6 +205,7 @@
 package com.taobao.weex.appfram.storage;
 
 import com.taobao.weappplus_sdk.BuildConfig;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -218,8 +219,10 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import static org.powermock.api.mockito.PowerMockito.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyMapOf;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 /**
  * Created by sospartan on 7/28/16.
@@ -238,13 +241,15 @@ public class DefaultWXStorageTest {
   public PowerMockRule rule = new PowerMockRule();
 
   @Before
-  public void setup(){
+  public void setup() throws Exception{
     supplier = Mockito.mock(WXSQLiteOpenHelper.class);
     listener = Mockito.mock(IWXStorageAdapter.OnResultReceivedListener.class);
     storage = new DefaultWXStorage(RuntimeEnvironment.application);
 
     mockStatic(WXSQLiteOpenHelper.class);
-    PowerMockito.when(new WXSQLiteOpenHelper(RuntimeEnvironment.application)).thenReturn(supplier);
+    PowerMockito.whenNew(WXSQLiteOpenHelper.class)
+            .withArguments(RuntimeEnvironment.application)
+            .thenReturn(supplier);
   }
 
 

--- a/android/sdk/src/test/java/com/taobao/weex/appfram/storage/DefaultWXStorageTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/appfram/storage/DefaultWXStorageTest.java
@@ -244,8 +244,7 @@ public class DefaultWXStorageTest {
     storage = new DefaultWXStorage(RuntimeEnvironment.application);
 
     mockStatic(WXSQLiteOpenHelper.class);
-
-    PowerMockito.when(WXSQLiteOpenHelper.getInstance(RuntimeEnvironment.application)).thenReturn(supplier);
+    PowerMockito.when(new WXSQLiteOpenHelper(RuntimeEnvironment.application)).thenReturn(supplier);
   }
 
 


### PR DESCRIPTION
1. WXSQLiteOpenHelper是单例的， 且持有Context引用，不当使用可能会引起内存泄露.  （虽然目前传入的是WXEnvironment.sApplication）

2. WXPerformance#templateUrl字段从未赋值，我觉得可以在WXSDKInstance#renderByUrl中进行赋值.

