### PR TITLE
* [html5] stream module  cors cookie support

### DIFF
--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -69,6 +69,11 @@ function _xhr (config, callback, progressCallback) {
   xhr.responseType = config.type
   xhr.open(config.method, config.url, true)
 
+  // cors cookie support
+  if (config.withCrendentials === true) {
+    xhr.withCrendentials = true
+  }
+
   const headers = config.headers || {}
   for (const k in headers) {
     xhr.setRequestHeader(k, headers[k])
@@ -177,6 +182,7 @@ const stream = {
    *   - headers {obj}
    *   - url {string}
    *   - mode {string} 'cors' | 'no-cors' | 'same-origin' | 'navigate'
+   *   - withCrendentials {boolean}
    *   - body
    *   - type {string} 'json' | 'jsonp' | 'text'
    * @param  {string} callbackId


### PR DESCRIPTION
支持html5 中 stream module在跨域cors情况下带cookie

和[https://github.com/alibaba/weex/pull/1509](https://github.com/alibaba/weex/pull/1509)一样，更正了提交分支

