### PR TITLE
* [ios] fix WXSDKInstance rootview bug

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.h
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.h
@@ -21,7 +21,7 @@ extern NSString *const bundleUrlOptionKey;
 /**
  * The rootView which the weex bundle is rendered at.
  **/
-@property (nonatomic, strong) UIView *rootView;
+@property (nonatomic, strong, readonly) UIView *rootView;
 
 /**
  * The scriptURL of weex bundle.

--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -199,7 +199,7 @@ NSTimeInterval JSLibInitTime = 0;
     
     //TODO WXRootView
     WXPerformBlockOnMainThread(^{
-        self.rootView = [[WXView alloc] initWithFrame:self.frame];
+        _rootView = [[WXView alloc] initWithFrame:self.frame];
         if(self.onCreate) {
             self.onCreate(self.rootView);
         }


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->

WXSDKInstance 的rootView 定义 readwrite 属性，有可能会被如下使用

xxSDKInstance.rootView= self;

然后 在render 完成 oncreate返回的优势 rootview
会出现 self add self的问题
因此改成 readonly,后期有好的解决方案再改成readwrite
