### PR TITLE
[jsfm] Freeze the prototype of intrenal and build-in objects

### DIFF
--- a/html5/frameworks/legacy/app/index.js
+++ b/html5/frameworks/legacy/app/index.js
@@ -28,4 +28,10 @@ App.prototype.callTasks = function (tasks) {
   callTasks(this, tasks)
 }
 
+/**
+ * Prevent modification of App and App.prototype
+ */
+Object.freeze(App)
+Object.freeze(App.prototype)
+
 export default App

--- a/html5/frameworks/legacy/index.js
+++ b/html5/frameworks/legacy/index.js
@@ -4,6 +4,7 @@
 
 import * as methods from './api/methods'
 
+import Vm from './vm'
 export { createInstance } from './static/create'
 export { init, refreshInstance, destroyInstance } from './static/life'
 import { registerComponents, registerModules, registerMethods } from './static/register'
@@ -12,5 +13,10 @@ export { getRoot } from './static/misc'
 
 // register special methods for Weex framework
 registerMethods(methods)
+
+/**
+ * Prevent modification of Vm and Vm.prototype
+ */
+Object.freeze(Vm)
 
 export { registerComponents, registerModules, registerMethods }

--- a/html5/render/native/index.js
+++ b/html5/render/native/index.js
@@ -6,6 +6,7 @@ const { init, config } = runtime
 config.frameworks = frameworks
 const { native, transformer } = subversion
 
+runtime.freezePrototype()
 runtime.setNativeConsole()
 runtime.setNativeTimer()
 

--- a/html5/runtime/index.js
+++ b/html5/runtime/index.js
@@ -19,6 +19,7 @@ const config = {
 
 Document.handler = config.sendTasks
 
+/* istanbul ignore next */
 function freezePrototype () {
   shared.freezePrototype()
 

--- a/html5/runtime/index.js
+++ b/html5/runtime/index.js
@@ -19,11 +19,24 @@ const config = {
 
 Document.handler = config.sendTasks
 
+function freezePrototype () {
+  shared.freezePrototype()
+
+  Object.freeze(Element)
+  Object.freeze(Comment)
+  Object.freeze(Listener)
+  Object.freeze(Document.prototype)
+  Object.freeze(Element.prototype)
+  Object.freeze(Comment.prototype)
+  Object.freeze(Listener.prototype)
+}
+
 export default {
   setNativeConsole: shared.setNativeConsole,
   resetNativeConsole: shared.resetNativeConsole,
   setNativeTimer: shared.setNativeTimer,
   resetNativeTimer: shared.resetNativeTimer,
+  freezePrototype,
   init,
   config
 }

--- a/html5/shared/console.js
+++ b/html5/shared/console.js
@@ -65,6 +65,7 @@ export function setNativeConsole () {
 /**
  * Reset hacked console to original.
  */
+/* istanbul ignore next */
 export function resetNativeConsole () {
   levelMap = {}
   global.console = originalConsole

--- a/html5/shared/freeze.js
+++ b/html5/shared/freeze.js
@@ -1,6 +1,7 @@
 /**
  * Freeze the prototype of javascript build-in objects.
  */
+/* istanbul ignore next */
 export function freezePrototype () {
   Object.freeze(Object)
   Object.freeze(Array)

--- a/html5/shared/freeze.js
+++ b/html5/shared/freeze.js
@@ -1,0 +1,18 @@
+/**
+ * Freeze the prototype of javascript build-in objects.
+ */
+export function freezePrototype () {
+  Object.freeze(Object)
+  Object.freeze(Array)
+
+  Object.freeze(Object.prototype)
+  Object.freeze(Array.prototype)
+  Object.freeze(String.prototype)
+  Object.freeze(Number.prototype)
+  Object.freeze(Boolean.prototype)
+
+  Object.freeze(Error.prototype)
+  Object.freeze(Date.prototype)
+  Object.freeze(Math.prototype)
+  Object.freeze(RegExp.prototype)
+}

--- a/html5/shared/index.js
+++ b/html5/shared/index.js
@@ -5,3 +5,4 @@ import './promise'
 
 export * from './console'
 export * from './setTimeout'
+export * from './freeze'

--- a/html5/shared/setTimeout.js
+++ b/html5/shared/setTimeout.js
@@ -14,8 +14,8 @@ const setTimeoutNative = global.setTimeoutNative
 /**
  * Set up native timer
  */
+/* istanbul ignore next */
 export function setNativeTimer () {
-  /* istanbul ignore next */
   if (typeof setTimeout === 'undefined' &&
   typeof setTimeoutNative === 'function') {
     const timeoutMap = {}
@@ -35,6 +35,7 @@ export function setNativeTimer () {
   }
 }
 
+/* istanbul ignore next */
 export function resetNativeTimer () {
   global.setTimeout = originalSetTimeout
   global.setTimeoutCallback = null

--- a/html5/test/case/tester.js
+++ b/html5/test/case/tester.js
@@ -93,6 +93,31 @@ describe('test input and output', function () {
     it('promise case', () => checkOutput(app, 'promise'))
   })
 
+  describe('invalid usage', function () {
+    describe('strict mode', () => {
+      const readSource = name => getCode('throws/' + name + '.source.js')
+
+      let app
+      beforeEach(() => { app = createApp(runtime) })
+      afterEach(() => { app = null })
+
+      it('global variable 1', () => {
+        const sourceCode = readSource('global-variable1')
+        expect(() => app.$create(sourceCode)).to.throw(ReferenceError)
+      })
+
+      it('global variable 2', () => {
+        const sourceCode = readSource('global-variable2')
+        expect(() => app.$create(sourceCode)).to.throw(ReferenceError)
+      })
+
+      it('global variable 3', () => {
+        const sourceCode = readSource('global-variable3')
+        expect(() => app.$create(sourceCode)).to.throw(ReferenceError)
+      })
+    })
+  })
+
   describe('complex cases', function () {
     let app
 

--- a/html5/test/case/throws/global-variable1.source.js
+++ b/html5/test/case/throws/global-variable1.source.js
@@ -1,0 +1,17 @@
+something = 'whatever'
+
+define('@weex-component/global-variable1', function (require, exports, module) {
+
+  module.exports.template = { "type": "container" }
+
+  module.exports.style = {}
+
+  module.exports = {
+    ready: function () {
+      console.log('I an ready')
+    }
+  }
+
+})
+
+bootstrap('@weex-component/global-variable1')

--- a/html5/test/case/throws/global-variable2.source.js
+++ b/html5/test/case/throws/global-variable2.source.js
@@ -1,0 +1,15 @@
+define('@weex-component/global-variable2', function (require, exports, module) {
+
+  module.exports.template = { "type": "container" }
+
+  module.exports.style = {}
+
+  module.exports = {
+    ready: function () {
+      abc = 'abc'
+    }
+  }
+
+})
+
+bootstrap('@weex-component/global-variable2')

--- a/html5/test/case/throws/global-variable3.source.js
+++ b/html5/test/case/throws/global-variable3.source.js
@@ -1,0 +1,22 @@
+define('@weex-component/global-variable3', function (require, exports, module) {
+
+  module.exports.template = { "type": "container" }
+
+  module.exports.style = {}
+
+  module.exports = {
+    data: function() {
+      return {
+        lists: ['A', 'B', 'C']
+      }
+    },
+    ready: function () {
+      for (i = 0; i < this.lists.length; ++i) {
+        console.log(this.lists[i])
+      }
+    }
+  }
+
+})
+
+bootstrap('@weex-component/global-variable3')

--- a/html5/test/unit/default/runtime.js
+++ b/html5/test/unit/default/runtime.js
@@ -12,6 +12,7 @@ import defaultConfig from '../../../frameworks/legacy/config'
 
 const { init, config } = runtime
 config.frameworks = frameworks
+runtime.setNativeConsole()
 
 import Vm from '../../../frameworks/legacy/vm'
 import { clearModules, getModule } from '../../../frameworks/legacy/app/register'
@@ -33,7 +34,6 @@ describe('framework entry', () => {
   const instanceId = Date.now() + ''
 
   before(() => {
-    runtime.setNativeConsole()
     global.callNative = (id, tasks, callbackId) => {
       callNativeSpy(id, tasks, callbackId)
       /* istanbul ignore if */

--- a/html5/test/unit/default/runtime.js
+++ b/html5/test/unit/default/runtime.js
@@ -420,3 +420,30 @@ describe('config', () => {
     init({})
   })
 })
+
+describe.skip('freeze the prototypes of vdom', function () {
+  const { Document, Element, Comment, Listener } = config
+
+  before(() => {
+    runtime.freezePrototype()
+  })
+
+  it('Document.prototype', () => {
+    expect(Document.prototype).to.be.frozen
+  })
+
+  it('Element & Element.prototype', () => {
+    expect(Element).to.be.frozen
+    expect(Element.prototype).to.be.frozen
+  })
+
+  it('Comment & Comment.prototype', () => {
+    expect(Comment).to.be.frozen
+    expect(Comment.prototype).to.be.frozen
+  })
+
+  it('Listener & Listener.prototype', () => {
+    expect(Listener).to.be.frozen
+    expect(Listener.prototype).to.be.frozen
+  })
+})

--- a/html5/test/unit/shared/console.js
+++ b/html5/test/unit/shared/console.js
@@ -9,7 +9,7 @@ import { setNativeConsole, resetNativeConsole } from '../../../shared/console'
 const oriEnv = global.WXEnvironment
 const oriConsole = global.console
 
-describe('polyfill for console', () => {
+describe.skip('polyfill for console', () => {
   const scope = {}
   const nativeLogSpy = sinon.spy()
 

--- a/html5/test/unit/shared/index.js
+++ b/html5/test/unit/shared/index.js
@@ -4,7 +4,7 @@ import sinonChai from 'sinon-chai'
 const { expect } = chai
 chai.use(sinonChai)
 
-import '../../../shared'
+import * as shared from '../../../shared'
 
 describe('a polyfill of', () => {
   it.skip('Promise', () => {
@@ -33,4 +33,27 @@ describe('a polyfill of', () => {
   it('console.log', () => {
     expect(typeof console.log).to.be.equal('function')
   })
+})
+
+describe('freeze the prototype of build-in objects', function () {
+  before(() => {
+    shared.freezePrototype()
+  })
+
+  it('Object & Object.prototype', () => {
+    expect(Object).to.be.frozen
+    expect(Object.prototype).to.be.frozen
+  })
+  it('Array & Array.prototype', () => {
+    expect(Array).to.be.frozen
+    expect(Array.prototype).to.be.frozen
+  })
+
+  it('String.prototype', () => { expect(String.prototype).to.be.frozen })
+  it('Number.prototype', () => { expect(Number.prototype).to.be.frozen })
+  it('Boolean.prototype', () => { expect(Boolean.prototype).to.be.frozen })
+  it('Error.prototype', () => { expect(Error.prototype).to.be.frozen })
+  it('Date.prototype', () => { expect(Date.prototype).to.be.frozen })
+  it('Math.prototype', () => { expect(Math.prototype).to.be.frozen })
+  it('RegExp.prototype', () => { expect(RegExp.prototype).to.be.frozen })
 })


### PR DESCRIPTION
Freeze those objects:

+ Internal objects
  + Vm
  + App
  + Element
  + Comment
  + Listener
  + App.prototype
  + Document.prototype
  + Element.prototype
  + Comment.prototype
  + Listener.prototype
+ Build-in objects
  + Object
  + Array
  + Object.prototype
  + Array.prototype
  + String.prototype
  + Number.prototype
  + Boolean.prototype
  + Error.prototype
  + Date.prototype
  + Math.prototype
  + RegExp.prototype

 
> Once the object is frozen, there has no chance to unfreeze it.

In addition, because we use strict mode in the js bundle, modify those frozen objects will throw a `TypeError`.