### PR TITLE
* [html5] fix #1477, work with new wwp

### DIFF
--- a/html5/browser/extend/index.js
+++ b/html5/browser/extend/index.js
@@ -3,9 +3,10 @@ import packages from './packer'
 // install the apis and components as packages.
 export default {
   init (Weex) {
-    if (!packages || !packages.length) {
+    const packagesList = packages && Object.keys(packages)
+    if (!packagesList || !packagesList.length) {
       return
     }
-    packages.forEach(pkg => Weex.install(pkg))
+    packagesList.forEach(pkgName => Weex.install(packages[pkgName]))
   }
 }


### PR DESCRIPTION
新版的 `wwp` 导出的是对象而非数组