### PR TITLE
Ios feature picker

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -40,7 +40,8 @@
     [self registerModule:@"storage" withClass:NSClassFromString(@"WXStorageModule")];
     [self registerModule:@"clipboard" withClass:NSClassFromString(@"WXClipboardModule")];
     [self registerModule:@"globalEvent" withClass:NSClassFromString(@"WXGlobalEventModule")];
-	[self registerModule:@"canvas" withClass:NSClassFromString(@"WXCanvasModule")];
+    [self registerModule:@"canvas" withClass:NSClassFromString(@"WXCanvasModule")];
+    [self registerModule:@"picker" withClass:NSClassFromString(@"WXPickerModule")];
 }
 
 + (void)registerModule:(NSString *)name withClass:(Class)clazz

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.h
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.h
@@ -9,6 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "WXModuleProtocol.h"
 
-@interface WXPickerModule : NSObject <WXModuleProtocol>
+@interface WXPickerModule : NSObject <WXModuleProtocol,UIPickerViewDelegate>
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.h
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.h
@@ -1,0 +1,14 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import "WXModuleProtocol.h"
+
+@interface WXPickerModule : NSObject <WXModuleProtocol>
+
+@end

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -21,6 +21,9 @@
 
 //data
 @property(nonatomic,copy)NSArray *items;
+@property(nonatomic)BOOL isAnimating;
+@property(nonatomic)NSInteger index;
+@property(nonatomic,copy)WXModuleCallback callback;
 
 @end
 
@@ -31,15 +34,71 @@ WX_EXPORT_METHOD(@selector(pick:index:callback:))
 
 #pragma mark -
 #pragma mark Single Picker
--(void)pick:(NSArray *)items index:(long long)index callback:(WXModuleCallback)callback
+-(void)pick:(NSArray *)items index:(NSInteger)index callback:(WXModuleCallback)callback
 {
-    
+    [self createPicker:items index:index];
+    self.callback = callback;
 }
 
--(void)createPicker:(NSArray *)items index:(long long)index
+-(void)createPicker:(NSArray *)items index:(NSInteger)index
 {
     [self configPickerView];
     self.items = [items copy];
+    self.index = index;
+    if(items && index < [items count])
+    {
+        [self.picker selectRow:index inComponent:0 animated:NO];
+    }else if(items && [items count]>0)
+    {
+        [self.picker selectRow:0 inComponent:0 animated:NO];
+    }
+    [self show];
+}
+
+-(void)show
+{
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
+    [window addSubview:self.backgroudView];
+    if(self.isAnimating)
+    {
+        return;
+    }
+    self.isAnimating = YES;
+    self.backgroudView.hidden = NO;
+    [UIView animateWithDuration:0.35f animations:^{
+        self.pickerView.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height - WXPickerHeight, [UIScreen mainScreen].bounds.size.width, WXPickerHeight);
+        self.backgroudView.alpha = 1;
+    } completion:^(BOOL finished) {
+        self.isAnimating = NO;
+    }];
+}
+
+-(void)hide
+{
+    if(self.isAnimating)
+    {
+        return;
+    }
+    self.isAnimating = YES;
+    [UIView animateWithDuration:0.35f animations:^{
+        self.pickerView.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height, [UIScreen mainScreen].bounds.size.width, WXPickerHeight);
+        self.backgroudView.alpha = 0;
+    } completion:^(BOOL finished) {
+        self.backgroudView.hidden = YES;
+        self.isAnimating = NO;
+        [self.backgroudView removeFromSuperview];
+    }];
+}
+
+-(void)cancel:(id)sender
+{
+    [self hide];
+}
+
+-(void)done:(id)sender
+{
+    [self hide];
+    self.callback([NSNumber numberWithInteger:self.index]);
 }
 
 #pragma mark -
@@ -52,19 +111,33 @@ WX_EXPORT_METHOD(@selector(pick:index:callback:))
         self.backgroudView = [self createBackgroudView];
         UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
         [self.backgroudView addGestureRecognizer:tapGesture];
+        
     }
     
     if(!self.pickerView)
     {
         self.pickerView = [self createPickerView];
+        CGRect pickerFrame = CGRectMake(0, 44, [UIScreen mainScreen].bounds.size.width, WXPickerHeight-44);
+        UIToolbar *toolBar=[[UIToolbar alloc]initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, 44)];
+        [toolBar setBackgroundColor:[UIColor whiteColor]];
+        UIBarButtonItem* noSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+        noSpace.width=10;
+        UIBarButtonItem* doneBtn = [[UIBarButtonItem alloc]initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(done:)];
+        UIBarButtonItem *flexSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+        UIBarButtonItem* cancelBtn = [[UIBarButtonItem alloc]initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+        [toolBar setItems:[NSArray arrayWithObjects:noSpace,cancelBtn,flexSpace,doneBtn,noSpace, nil]];
+        [self.pickerView addSubview:toolBar];
     }
     
     if(!self.picker)
     {
-        self.picker = [[UIDatePicker alloc]init];
+        self.picker = [[UIPickerView alloc]init];
+        self.picker.delegate = self;
         CGRect pickerFrame = CGRectMake(0, 44, [UIScreen mainScreen].bounds.size.width, WXPickerHeight-44);
         self.picker.backgroundColor = [UIColor whiteColor];
         self.picker.frame = pickerFrame;
+        [self.pickerView addSubview:self.picker];
+        [self.backgroudView addSubview:self.pickerView];
     }
 }
 
@@ -95,8 +168,14 @@ WX_EXPORT_METHOD(@selector(pick:index:callback:))
 {
     return 44.0f;
 }
+
+- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component
+{
+    return self.items[row];
+}
+
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
-    
+    self.index = row;
 }
 @end

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -57,6 +57,7 @@ WX_EXPORT_METHOD(@selector(pick:index:callback:))
 
 -(void)show
 {
+    [[[UIApplication sharedApplication] keyWindow] endEditing:YES];  //收起键盘
     UIWindow *window = [UIApplication sharedApplication].keyWindow;
     [window addSubview:self.backgroudView];
     if(self.isAnimating)

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -100,6 +100,7 @@ WX_EXPORT_METHOD(@selector(pick:index:callback:))
 {
     [self hide];
     self.callback([NSNumber numberWithInteger:self.index]);
+    self.callback=nil;
 }
 
 #pragma mark -

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -1,0 +1,102 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "WXPickerModule.h"
+#import <UIKit/UIPickerView.h>
+#import <UIKit/UIKit.h>
+
+#define WXPickerHeight 266
+
+@interface WXPickerModule()
+
+//view
+@property(nonatomic,strong)UIPickerView *picker;
+@property(nonatomic,strong)UIView *backgroudView; //手势触摸，隐藏picker
+@property(nonatomic,strong)UIView *pickerView;    //picker页面
+
+//data
+@property(nonatomic,copy)NSArray *items;
+
+@end
+
+@implementation WXPickerModule
+@synthesize weexInstance;
+
+WX_EXPORT_METHOD(@selector(pick:index:callback:))
+
+#pragma mark -
+#pragma mark Single Picker
+-(void)pick:(NSArray *)items index:(long long)index callback:(WXModuleCallback)callback
+{
+    
+}
+
+-(void)createPicker:(NSArray *)items index:(long long)index
+{
+    [self configPickerView];
+    self.items = [items copy];
+}
+
+#pragma mark -
+#pragma mark Pikcer View
+
+-(void *)configPickerView
+{
+    if(!self.backgroudView)
+    {
+        self.backgroudView = [self createBackgroudView];
+        UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
+        [self.backgroudView addGestureRecognizer:tapGesture];
+    }
+    
+    if(!self.pickerView)
+    {
+        self.pickerView = [self createPickerView];
+    }
+    
+    if(!self.picker)
+    {
+        self.picker = [[UIDatePicker alloc]init];
+        CGRect pickerFrame = CGRectMake(0, 44, [UIScreen mainScreen].bounds.size.width, WXPickerHeight-44);
+        self.picker.backgroundColor = [UIColor whiteColor];
+        self.picker.frame = pickerFrame;
+    }
+}
+
+-(UIView *)createPickerView
+{
+    UIView *view = [UIView new];
+    view.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height, [UIScreen mainScreen].bounds.size.width, WXPickerHeight);
+    view.backgroundColor = [UIColor whiteColor];
+    return view;
+}
+
+-(UIView *)createBackgroudView
+{
+    UIView *view = [UIView new];
+    view.frame = [UIScreen mainScreen].bounds;
+    view.backgroundColor = [UIColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:0.4];
+    return view;
+}
+
+#pragma mark -
+#pragma UIPickerDelegate
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
+{
+    return [self.items count];
+}
+
+- (CGFloat)pickerView:(UIPickerView *)pickerView rowHeightForComponent:(NSInteger)component
+{
+    return 44.0f;
+}
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
+{
+    
+}
+@end


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->

在千牛的工作台模块中添加选择功能的时候
没有通用性的picker，千牛无法实现城市的选择，订单搜索条件过滤等功能
期望：
实现通用性的picker
解决方案：
实现picker组件

具体方案及接口
组件名字
picker
普通单选选择器:


属性名 | 类型 | 默认值 |说明
----|------|----|----
items | Array  | []| 传给picker的items数组
index | int  | 0| 是数字，表示选择了 items 中的第index个值，从0开始。
function | 回调 |  | 用户点击确定后，返回结果 index

使用例子
```js
pick:function (e) 
{
        var picker = require('@weex-module/picker');
        var items = new Array("Saab","Volvo","BMW");
        var index = 0;
        var self = this;
        picker.pick(items,index,function (index) {
          var value = items[index];
        });
}
```
相关PR
[android picker 40](https://github.com/sospartan/weex/pull/40)

参考 http://velocity.alibaba-inc.com/issues/3034