### PR TITLE
[jsfm] Fix the rollup tree shaking accuracy

### DIFF
--- a/html5/frameworks/legacy/app/downgrade.js
+++ b/html5/frameworks/legacy/app/downgrade.js
@@ -109,12 +109,12 @@ export function check (config, deviceInfo) {
   if (typof(config) === 'function') {
     let customDowngrade = config.call(this, deviceInfo, {
       semver: semver,
-      normalizeVersion: this.normalizeVersion
+      normalizeVersion
     })
 
     customDowngrade = !!customDowngrade
 
-    result = customDowngrade ? this.getError('custom', '', 'custom params') : result
+    result = customDowngrade ? getError('custom', '', 'custom params') : result
   }
   else {
     config = isPlainObject(config) ? config : {}
@@ -132,18 +132,18 @@ export function check (config, deviceInfo) {
       const criteria = cObj[i]
 
       if (criteria && isVersion) {
-        const c = this.normalizeVersion(criteria)
-        const d = this.normalizeVersion(deviceInfo[i])
+        const c = normalizeVersion(criteria)
+        const d = normalizeVersion(deviceInfo[i])
 
         if (semver.satisfies(d, c)) {
-          result = this.getError(key, val, criteria)
+          result = getError(key, val, criteria)
           break
         }
       }
       else if (isDeviceModel) {
         const _criteria = typof(criteria) === 'array' ? criteria : [criteria]
         if (_criteria.indexOf(val) >= 0) {
-          result = this.getError(key, val, criteria)
+          result = getError(key, val, criteria)
           break
         }
       }

--- a/html5/shared/index.js
+++ b/html5/shared/index.js
@@ -1,7 +1,13 @@
 import './arrayFrom'
 import './objectAssign'
 import './objectSetPrototypeOf'
+
+// import promise hack and polyfills
 import './promise'
+import 'core-js/modules/es6.object.to-string'
+import 'core-js/modules/es6.string.iterator'
+import 'core-js/modules/web.dom.iterable'
+import 'core-js/modules/es6.promise'
 
 export * from './console'
 export * from './setTimeout'

--- a/html5/shared/promise.js
+++ b/html5/shared/promise.js
@@ -6,7 +6,3 @@ const { WXEnvironment } = global
 if (WXEnvironment && WXEnvironment.platform === 'iOS') {
   global.Promise = undefined
 }
-import 'core-js/modules/es6.object.to-string'
-import 'core-js/modules/es6.string.iterator'
-import 'core-js/modules/web.dom.iterable'
-import 'core-js/modules/es6.promise'

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-postcss": "^0.2.0",
     "rollup-plugin-replace": "^1.1.1",
+    "rollup-plugin-uglify": "^1.0.1",
     "rollup-watch": "^2.5.0",
     "selenium-server": "2.53.1",
     "serve": "^1.4.0",


### PR DESCRIPTION
Rollup mistakenly eliminated few functions by tree shaking. Use a little tricks to make it works well.

+ Remove the usage of `this` in `downgrade`, just call the method directly.
+ Import promise hack (for iOS) before its polyfill.