### PR TITLE
* [html5] stream module  cors cookie support fixbug

### DIFF
--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -70,8 +70,8 @@ function _xhr (config, callback, progressCallback) {
   xhr.open(config.method, config.url, true)
 
   // cors cookie support
-  if (config.withCrendentials === true) {
-    xhr.withCrendentials = true
+  if (config.withCredentials === true) {
+    xhr.withCredentials = true
   }
 
   const headers = config.headers || {}

--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -182,7 +182,7 @@ const stream = {
    *   - headers {obj}
    *   - url {string}
    *   - mode {string} 'cors' | 'no-cors' | 'same-origin' | 'navigate'
-   *   - withCrendentials {boolean}
+   *   - withCredentials {boolean}
    *   - body
    *   - type {string} 'json' | 'jsonp' | 'text'
    * @param  {string} callbackId


### PR DESCRIPTION
经过确认之前stream module  cors cookie support中的 withCrendentials这个单词拼错了，需要改成withCredentials
