### PR TITLE
Html5 feature image placeholder

### DIFF
--- a/html5/render/browser/extend/components/image/index.js
+++ b/html5/render/browser/extend/components/image/index.js
@@ -35,6 +35,10 @@ const attr = {
     this.enableLazyload(val)
   },
 
+  placeholder: function (val) {
+    this.node.dataset.placeholder = val
+  },
+
   resize: function (val) {
     if (RESIZE_MODES.indexOf(val) === -1) {
       val = 'stretch'

--- a/html5/render/browser/extend/components/image/index.js
+++ b/html5/render/browser/extend/components/image/index.js
@@ -11,6 +11,7 @@ const DEFAULT_RESIZE_MODE = 'stretch'
 /**
  * resize: 'cover' | 'contain' | 'stretch', default is 'stretch'
  * src: url
+ * placeholder / place-holder: url
  */
 const proto = {
   create () {
@@ -37,6 +38,11 @@ const attr = {
 
   placeholder: function (val) {
     this.node.dataset.placeholder = val
+  },
+
+  // alias for placeholder (place-holder)
+  placeHolder: function (val) {
+    return this.attr.placeholder.call(this, val)
   },
 
   resize: function (val) {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cubicbezier": "^0.1.1",
     "envd": "^0.1.1",
     "httpurl": "^0.1.1",
-    "lazyimg": "^0.1.2",
+    "lazyimg": "^0.1.3",
     "modals": "^0.1.6",
     "scroll-to": "0.0.2",
     "semver": "^5.1.0",


### PR DESCRIPTION
add `placeholder` attribute support for image.

demo:

```html
<template>
  <div>
    <image
      style="width:320;height:100;"
      src="//xxxxxxx.com/xx.jpg"
      placeholder="//img.alicdn.com/simba/img/TB1l5R_OXXXXXcrXpXXSutbFXXX.jpg"></image>
  </div>
</template>
```

the `src` is invalid, and it will use the `placeholder` image instead.
