### PR TITLE
+ [ios] add component count to same as android  && add key to userinf…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
+++ b/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
@@ -93,16 +93,15 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
     if (instance.userInfo[@"weex_bundlejs_requestType"]) {
         commitDict[@"requestType"] = instance.userInfo[@"weex_bundlejs_requestType"];
     }
-#if DEBUG
+    if (instance.userInfo[WXCUSTOMMONITORINFO]) {
+        commitDict[WXCUSTOMMONITORINFO] = instance.userInfo[WXCUSTOMMONITORINFO];
+    }
     WXPerformBlockOnComponentThread(^{
         commitDict[@"componentCount"] = @([instance numberOfComponents]);
         WXPerformBlockOnMainThread(^{
-#endif
     [self commitPerformanceWithDict:commitDict instance:instance];
-#if DEBUG
         });
     });
-#endif
 }
 
 + (void)commitPerformanceWithDict:(NSMutableDictionary *)commitDict instance:(WXSDKInstance *)instance

--- a/ios/sdk/WeexSDK/Sources/Protocol/WXAppMonitorProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXAppMonitorProtocol.h
@@ -14,6 +14,7 @@
 #define JSLIBVERSION        @"JSLibVersion"
 #define WXREQUESTTYPE       @"requestType"
 #define WXCONNECTIONTYPE    @"connectionType"
+#define WXCUSTOMMONITORINFO @"customMonitorInfo"
 
 #define SDKINITTIME         @"SDKInitTime"
 #define SDKINITINVOKETIME   @"SDKInitInvokeTime"


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->

1. 为了和安卓一致，获取component 的count ，并提交给monitor
2. 给userinfo增加了一个key，方便用户存储自己的信息，然后提交给monitor