### PR TITLE
Fix the regular expression of commit message

### DIFF
--- a/bin/commit-msg.sh
+++ b/bin/commit-msg.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # Validate commit log
-commit_regex='^Merge.+|[+*-] \[(android|ios|jsfm|html5|component|doc|website|example|test|all)\] [^\n]{1,50}'
+commit_regex='^Merge.+|[+*-] \[(android|ios|jsfm|html5|component|doc|website|example|test|all)\] .{1,50}'
 
 if ! grep -iqE "$commit_regex" "$1"; then
     echo "ERROR: commit log format is not correct!"
     echo "See https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#commit-log"
     exit 1
 fi
-# FIXME no effect after editor (like vim) exits 
+# FIXME no effect after editor (like vim) exits
 # ISSUE merge or conflict


### PR DESCRIPTION
As described in #1567 , use `.` instead of `[^\n]` in `bin/commit-msg.sh`.