### PR TITLE
[jsfm] Mock the 'global' variable for js bundle

### DIFF
--- a/html5/frameworks/legacy/app/ctrl/init.js
+++ b/html5/frameworks/legacy/app/ctrl/init.js
@@ -63,7 +63,7 @@ export function init (app, code, data) {
   }
 
   // wrap IFFE and use strict mode
-  functionBody = `(function(){'use strict'; ${functionBody} })()`
+  functionBody = `(function(global){"use strict"; ${functionBody} })(Object.create(this))`
 
   // run code and get result
   const { WXEnvironment } = global


### PR DESCRIPTION
Javascript strict mode can prevent developer from creating global variables by accident, but it can't stop developer creating global variables intentionally (such as `global.cache = {}`).

But if we wrap a function like this:

```js
(function (global) {
  "use strict";

  /* function body */

})( Object.create(this) )
```

The `global` variable which js bundle can get is `Object.create(global)` in fact. It can access all global properties, however, add or modify properties on it will not affect the real global, and it will be cleared when the instance is destroyed.
