### PR TITLE
[jsfm] Fix the npm run build script

### DIFF
--- a/html5/frameworks/legacy/api/methods.js
+++ b/html5/frameworks/legacy/api/methods.js
@@ -1,7 +1,9 @@
 /**
  * @fileOverview The api for invoking with "$" prefix
  */
-import { nativeComponentMap } from '../config'
+import config from '../config'
+
+const { nativeComponentMap } = config
 
 /**
  * ==========================================================

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:browser:common": "rollup -c build/rollup.browser.common.config.js",
     "build:examples": "webpack --config build/webpack.examples.config.js",
     "build:test": "webpack --config build/webpack.test.config.js",
-    "build": "npm run build:native && npm run build:browser && npm run build:examples && npm run build:examples:vue && npm run build:test",
+    "build": "npm run build:native && npm run build:browser && npm run build:examples && npm run build:test",
     "dist:browser": "npm run build:browser && npm run build:browser:common && bash ./bin/dist-browser.sh",
     "dist": "npm run dist:browser",
     "dev:native": "rollup -w -c build/rollup.config.js",


### PR DESCRIPTION
Fix the `npm run build` script.

`npm run build:examples:vue` is removed, just use `npm run build:examples` instead. 