### PR TITLE
[jsfm] Removed document parameter from running js bundle.

### DIFF
--- a/html5/frameworks/legacy/app/ctrl/init.js
+++ b/html5/frameworks/legacy/app/ctrl/init.js
@@ -97,7 +97,6 @@ export function init (app, code, data) {
     const fn = new Function(
       'define',
       'require',
-      'document',
       'bootstrap',
       'register',
       'render',
@@ -116,7 +115,6 @@ export function init (app, code, data) {
     fn(
       bundleDefine,
       bundleRequire,
-      bundleDocument,
       bundleBootstrap,
       bundleRegister,
       bundleRender,
@@ -134,7 +132,6 @@ export function init (app, code, data) {
     const fn = new Function(
       'define',
       'require',
-      'document',
       'bootstrap',
       'register',
       'render',
@@ -149,7 +146,6 @@ export function init (app, code, data) {
     fn(
       bundleDefine,
       bundleRequire,
-      bundleDocument,
       bundleBootstrap,
       bundleRegister,
       bundleRender,


### PR DESCRIPTION
To avoid conflict of document detection in JS bundle. For example `document.createTextNode('')` for `Promise` polyfill will go error.