### PR TITLE
+ [ios] fixbug textarea:textarea can not input chinese,when the value…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -384,8 +384,10 @@
 - (void)textViewDidChange:(UITextView *)textView
 {
     _placeHolderLabel.text = @"";
-    if (_inputEvent) {
-        [self fireEvent:@"input" params:@{@"value":textView.text}];
+    if (textView.markedTextRange == nil) {
+        if (_inputEvent) {
+            [self fireEvent:@"input" params:@{@"value":textView.text}];
+        }
     }
 }
 
@@ -396,7 +398,7 @@
     }
     if (_changeEvent) {
         if (![[textView text] isEqualToString:_changeEventString]) {
-            [self fireEvent:@"change" params:@{@"value":[textView text]} domChanges:@{@"attrs":@{@"value":[_textView text]}}];
+            [self fireEvent:@"change" params:@{@"value":[textView text]} domChanges:@{@"attrs":@{@"value":[textView text]}}];
         }
     }
     if (_blurEvent) {

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -225,11 +225,6 @@ WX_EXPORT_METHOD(@selector(blur))
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)dealloc {
-    
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 -(void)focus
 {
     if(self.view)


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->

## 问题
ios textarea 在value数据绑定后，无法输入中文
## 预期
能输入中文
## bug用例
http://weex.alibaba-inc.com/playground/de48af80a83543ec47fe3669d4dec5a6


顺便删除重复定义的代码