### PR TITLE
[jsfm] supported replacing process.env

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,16 +1,19 @@
 import { rollup } from 'rollup'
 import json from 'rollup-plugin-json'
 import eslint from 'rollup-plugin-eslint'
+import replace from 'rollup-plugin-replace'
 import nodeResolve from 'rollup-plugin-node-resolve'
 import commonjs from 'rollup-plugin-commonjs'
 import buble from 'rollup-plugin-buble'
+
+const env = (process.argv.indexOf('--dev') >= 0) ? '' : 'production'
 
 const pkg = require('../package.json')
 const version = pkg.subversion.framework
 const date = new Date().toISOString().split('T')[0].replace(/\-/g, '')
 const banner = `\
 (this.nativeLog || function(s) {console.log(s)})('START JS FRAMEWORK: ${version} Build ${date}');
-var global = this, process = { env: {}};var setTimeout = global.setTimeout;
+var global = this, process = { env: {}}; var setTimeout = global.setTimeout;
 `
 
 export default {
@@ -18,11 +21,14 @@ export default {
   dest: './dist/native.js',
   banner,
   format: 'umd',
-  sourceMap: 'inline',
+  sourceMap: (env === 'production') ? false : 'inline',
   plugins: [
     json(),
     eslint({
       exclude: './package.json'
+    }),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(env)
     }),
     nodeResolve({
       jsnext: true,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "postinstall": "bash ./bin/install-hooks.sh",
-    "build:native": "rollup -c build/rollup.config.js",
+    "build:native": "rollup -c build/rollup.config.js $1",
     "build:browser": "wwp && rollup -c build/rollup.browser.config.js",
     "build:browser:common": "rollup -c build/rollup.browser.common.config.js",
     "build:examples": "webpack --config build/webpack.examples.config.js",


### PR DESCRIPTION
Replacing `process.env` into `"dev"` or `"production"` in order to enable tree-shaking in rollup.

* `npm run build:native` will output a production version
* `rollup -c build/rollup.config.js --dev` or `npm run build:native -- --dev` will output a dev version

The sourcemap will be inlined in dev version but the production version will not.