### PR TITLE
Ios bugfix resetstyles

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -416,7 +416,7 @@ do {\
     [self syncTextStorageForView];
 }
 
-- (void)_updateAttributesOnComponentThread:(NSDictionary *)attributes resetStyles:(NSDictionary *)resetStyles
+- (void)_updateAttributesOnComponentThread:(NSDictionary *)attributes
 {
     [super _updateAttributesOnComponentThread:attributes];
     


### PR DESCRIPTION
之前代码不小心更改了_updateAttributesOnComponentThread ，造成多态失效，现在修复