### PR TITLE
[ios] text area cursor auto go to end

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -302,28 +302,6 @@
 {
     if (attributes[@"autofocus"]) {
         _autofocus = [attributes[@"autofocus"] boolValue];
-    }
-    if (attributes[@"disabled"]) {
-        _disabled = [attributes[@"disabled"] boolValue];
-    }
-    if (attributes[@"placeholder"]) {
-        _placeholderString = attributes[@"placeholder"];
-    }
-    if (attributes[@"value"]) {
-        NSString * value = [WXConvert NSString:attributes[@"value"]];
-        if (value) {
-            _textValue = value;
-            [self correctCursor];
-            if([value length] > 0) {
-                _placeHolderLabel.text = @"";
-            }
-        }
-    }
-}
-- (void)_updateAttributesOnMainThread:(NSDictionary *)attributes
-{
-    if (attributes[@"autofocus"]) {
-        _autofocus = [attributes[@"autofocus"] boolValue];
         [self setAutofocus];
     }
     if (attributes[@"disabled"]) {
@@ -345,7 +323,6 @@
             }
         }
     }
-    
 }
 
 #pragma mark - upate styles

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -81,6 +81,9 @@
 @property (nonatomic, assign) CGSize keyboardSize;
 @property (nonatomic, assign) CGRect rootViewOriginFrame;
 
+//private
+@property(nonatomic) NSRange selectedRange; //save selectedrange. because re layout change textview selectedRange
+
 @end
 
 @implementation WXTextAreaComponent {
@@ -247,6 +250,14 @@
     return color;
 }
 
+-(void)correctCursor
+{
+    if(self.selectedRange.location != 0 && self.textView.selectedRange.location != self.selectedRange.location)
+    {
+        self.textView.selectedRange = self.selectedRange;
+    }
+}
+
 #pragma mark - add-remove Event
 - (void)addEvent:(NSString *)eventName
 {
@@ -302,6 +313,7 @@
         NSString * value = [WXConvert NSString:attributes[@"value"]];
         if (value) {
             _textValue = value;
+            [self correctCursor];
             if([value length] > 0) {
                 _placeHolderLabel.text = @"";
             }
@@ -327,11 +339,13 @@
         if (value) {
             _textValue = value;
             _textView.text = _textValue;
+            [self correctCursor];
             if([value length] > 0) {
                 _placeHolderLabel.text = @"";
             }
         }
     }
+    
 }
 
 #pragma mark - upate styles
@@ -377,7 +391,6 @@
         _border = border;
         [_textView setBorder:_border];
     }
-    
 }
 
 #pragma mark measure frame
@@ -432,6 +445,7 @@
     }else{
         [self setPlaceholderAttributedString];
     }
+    self.selectedRange = textView.selectedRange;
     if (textView.markedTextRange == nil) {
         if (_inputEvent) {
             [self fireEvent:@"input" params:@{@"value":textView.text}];
@@ -441,6 +455,7 @@
 
 - (void)textViewDidEndEditing:(UITextView *)textView
 {
+    self.selectedRange = NSMakeRange(0, 0);
     if (![textView.text length]) {
         [self setPlaceholderAttributedString];
     }


### PR DESCRIPTION
fix bug: text area cursor auto go to end .

reason: if attributes[@"value"] is exist. _updateAttributesOnMainThread will change textview text.the cursor go to end. 

solution: save the  textview  selectedRange , when set textview.text ,correct it