### PR TITLE
[ios] bugfix 1208 textdefaultheight

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -438,6 +438,11 @@ do {\
         _color = [UIColor blackColor];
         [self setNeedsRepaint];
     }
+    if ([elements containsObject:@"height"]) {
+        NSMutableDictionary *styles = [@{} mutableCopy];
+        [styles setValue:[NSString stringWithFormat:@"%f",_fontSize/WXScreenResizeRadio()] forKeyPath:@"height"];
+        [self _updateCSSNodeStyles:styles];
+    }
 }
 
 @end


### PR DESCRIPTION
 bug fix: when style change ，text not set height， text's heigh is same as font . like android