### PR TITLE
[ios] when style change , text height not set , text height should same as fontsize

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
@@ -110,9 +110,9 @@
 - (void)_removeFromSupercomponent;
 - (void)_moveToSupercomponent:(WXComponent *)newSupercomponent atIndex:(NSUInteger)index;
 
-- (void)_updateStylesOnComponentThread:(NSDictionary *)styles resetStyles:(NSDictionary *)resetStyles;
+- (void)_updateStylesOnComponentThread:(NSDictionary *)styles resetStyles:(NSMutableArray *)resetStyles;
 - (void)_updateAttributesOnComponentThread:(NSDictionary *)attributes;
-- (void)_updateStylesOnMainThread:(NSDictionary *)styles resetStyles:(NSDictionary *)resetStyles;
+- (void)_updateStylesOnMainThread:(NSDictionary *)styles resetStyles:(NSMutableArray *)resetStyles;
 - (void)_updateAttributesOnMainThread:(NSDictionary *)attributes;
 
 - (void)_addEventOnComponentThread:(NSString *)eventName;
@@ -142,6 +142,8 @@
 
 - (void)_updateCSSNodeStyles:(NSDictionary *)styles;
 
+- (void)_resetCSSNodeStyles:(NSArray *)styles;
+
 - (void)_recomputeCSSNodeChildren;
 
 - (void)_handleBorders:(NSDictionary *)styles isUpdating:(BOOL)updating;
@@ -150,7 +152,7 @@
 
 - (void)_updateViewStyles:(NSDictionary *)styles;
 
-- (void)_resetStyles:(NSDictionary *)styles;
+- (void)_resetStyles:(NSArray *)styles;
 
 - (void)_initEvents:(NSArray *)events;
 
@@ -163,12 +165,5 @@
 - (void)_handleFirstScreenTime;
 
 - (void)_resetNativeBorderRadius;
-/**
- * @abstract Called when component's style are reset
- *
- * @param elements The reset CSS Nodestyle's elements
- * @discussion It can be overrided to handle specific style reseting.
- **/
-- (void)_resetCSSNodeStyles:(NSArray *)elements;
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Component/WXLoadingIndicator.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXLoadingIndicator.m
@@ -75,9 +75,9 @@
 }
 
 #pragma mark -reset color
-- (void)resetStyles:(NSArray *)elements
+- (void)resetStyles:(NSArray *)styles
 {
-    if ([elements containsObject:@"color"]) {
+    if ([styles containsObject:@"color"]) {
         [self setColor:[UIColor blackColor]];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -570,9 +570,9 @@
 }
 
 #pragma mark -reset color
-- (void)resetStyles:(NSArray *)elements
+- (void)resetStyles:(NSArray *)styles
 {
-    if ([elements containsObject:@"color"]) {
+    if ([styles containsObject:@"color"]) {
         _color = [UIColor blackColor];
         [_textView setTextColor:[UIColor blackColor]];
     }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -438,6 +438,11 @@ do {\
         _color = [UIColor blackColor];
         [self setNeedsRepaint];
     }
+    if ([elements containsObject:@"height"]) {
+        NSMutableDictionary *styles = [@{} mutableCopy];
+        [styles setValue:[NSString stringWithFormat:@"%f",_fontSize/WXScreenResizeRadio()] forKeyPath:@"height"];
+        [self _updateCSSNodeStyles:styles];
+    }
 }
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -432,7 +432,7 @@ do {\
 }
 #endif
 
--(void)resetTextCSSNodes:(NSArray *)elements
+-(void)resetTextCSSNode:(NSArray *)elements
 {
     if ([elements containsObject:@"height"]) {
         _cssNode->style.dimensions[CSS_HEIGHT] = NAN;

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -432,21 +432,13 @@ do {\
 }
 #endif
 
--(void)resetTextCSSNode:(NSArray *)elements
-{
-    if ([elements containsObject:@"height"]) {
-        _cssNode->style.dimensions[CSS_HEIGHT] = NAN;
-    }
-    [self setNeedsLayout];
-}
-
 - (void)_resetCSSNodeStyles:(NSArray *)elements
 {
+    [super _resetCSSNodeStyles:elements];
     if ([elements containsObject:@"color"]) {
         _color = [UIColor blackColor];
         [self setNeedsRepaint];
     }
-    [self resetTextCSSNode:elements];
 }
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -432,17 +432,22 @@ do {\
 }
 #endif
 
+-(void)resetTextCSSNodes:(NSArray *)elements
+{
+    if([elements containsObject:@"height"])
+    {
+        _cssNode->style.dimensions[CSS_HEIGHT] = NAN;
+    }
+    [self setNeedsLayout];
+}
+
 - (void)_resetCSSNodeStyles:(NSArray *)elements
 {
     if ([elements containsObject:@"color"]) {
         _color = [UIColor blackColor];
         [self setNeedsRepaint];
     }
-    if ([elements containsObject:@"height"]) {
-        NSMutableDictionary *styles = [@{} mutableCopy];
-        [styles setValue:[NSString stringWithFormat:@"%f",_fontSize/WXScreenResizeRadio()] forKeyPath:@"height"];
-        [self _updateCSSNodeStyles:styles];
-    }
+    [self resetTextCSSNodes:elements];
 }
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -446,7 +446,7 @@ do {\
         _color = [UIColor blackColor];
         [self setNeedsRepaint];
     }
-    [self resetTextCSSNodes:elements];
+    [self resetTextCSSNode:elements];
 }
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -431,7 +431,7 @@ do {\
     return super.description;
 }
 #endif
-
+ 
 - (void)_resetCSSNodeStyles:(NSArray *)styles
 {
     [super _resetCSSNodeStyles:styles];

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -434,8 +434,7 @@ do {\
 
 -(void)resetTextCSSNodes:(NSArray *)elements
 {
-    if([elements containsObject:@"height"])
-    {
+    if ([elements containsObject:@"height"]) {
         _cssNode->style.dimensions[CSS_HEIGHT] = NAN;
     }
     [self setNeedsLayout];

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -407,9 +407,9 @@ do {\
     [self syncTextStorageForView];
 }
 
-- (void)_updateStylesOnComponentThread:(NSDictionary *)styles resetStyles:(NSDictionary *)resetStyles
+- (void)_updateStylesOnComponentThread:(NSDictionary *)styles resetStyles:(NSMutableArray *)resetStyles
 {
-    [super _updateStylesOnComponentThread:styles resetStyles:(NSDictionary *)resetStyles];
+    [super _updateStylesOnComponentThread:styles resetStyles:(NSMutableArray *)resetStyles];
     
     [self fillCSSStyles:styles];
     
@@ -432,10 +432,10 @@ do {\
 }
 #endif
 
-- (void)_resetCSSNodeStyles:(NSArray *)elements
+- (void)_resetCSSNodeStyles:(NSArray *)styles
 {
-    [super _resetCSSNodeStyles:elements];
-    if ([elements containsObject:@"color"]) {
+    [super _resetCSSNodeStyles:styles];
+    if ([styles containsObject:@"color"]) {
         _color = [UIColor blackColor];
         [self setNeedsRepaint];
     }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -636,9 +636,9 @@ WX_EXPORT_METHOD(@selector(blur))
 }
 
 #pragma mark -reset color
-- (void)resetStyles:(NSArray *)elements
+- (void)resetStyles:(NSArray *)styles
 {
-    if ([elements containsObject:@"color"]) {
+    if ([styles containsObject:@"color"]) {
         [_inputView setTextColor:[UIColor blackColor]];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -294,21 +294,18 @@ do {\
     WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
     
     // margin
-    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(margin, margin, CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(marginTop, margin[CSS_TOP], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(marginLeft, margin[CSS_LEFT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(marginRight, margin[CSS_RIGHT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(marginBottom, margin[CSS_BOTTOM], CSS_UNDEFINED)
     
     // border
-    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(borderWidth, border, CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(borderTopWidth, border[CSS_TOP], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(borderLeftWidth, border[CSS_LEFT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(borderRightWidth, border[CSS_RIGHT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(borderBottomWidth, border[CSS_BOTTOM], CSS_UNDEFINED)
     
     // padding
-    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(padding, padding, CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_TOP], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_LEFT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(paddingRight, padding[CSS_RIGHT], CSS_UNDEFINED)

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -265,8 +265,21 @@ do {\
 - (void)_resetCSSNode:(NSArray *)styles;
 {
     // flex
+    
+    WX_STYLE_RESET_CSS_NODE(alignContent, align_items, CSS_ALIGN_STRETCH)
+    WX_STYLE_RESET_CSS_NODE(alignContent, align_content, CSS_ALIGN_FLEX_START)
+
     WX_STYLE_RESET_CSS_NODE(flexDirection, flex_direction, CSS_FLEX_DIRECTION_COLUMN)
-    WX_STYLE_RESET_CSS_NODE(alignItems, align_items, CSS_ALIGN_STRETCH)
+
+    // dimension
+    WX_STYLE_RESET_CSS_NODE(width, dimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(height, dimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    
+    WX_STYLE_RESET_CSS_NODE(minWidth, minDimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(minHeight, minDimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    
+    WX_STYLE_RESET_CSS_NODE(maxWidth, maxDimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
     
     // position
     WX_STYLE_RESET_CSS_NODE(top, position[CSS_TOP], CSS_UNDEFINED)
@@ -274,31 +287,17 @@ do {\
     WX_STYLE_RESET_CSS_NODE(right, position[CSS_RIGHT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(bottom, position[CSS_BOTTOM], CSS_UNDEFINED)
     
-    // dimension
-    WX_STYLE_RESET_CSS_NODE(width, dimensions[CSS_WIDTH], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(height, dimensions[CSS_HEIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(minWidth, minDimensions[CSS_WIDTH], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(minHeight, minDimensions[CSS_HEIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(maxWidth, maxDimensions[CSS_WIDTH], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
-    
     // margin
-    WX_STYLE_RESET_CSS_NODE(marginTop, margin[CSS_TOP], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginLeft, margin[CSS_LEFT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginRight, margin[CSS_RIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginBottom, margin[CSS_BOTTOM], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginStart, margin[CSS_START], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginEnd, margin[CSS_END], CSS_UNDEFINED)
     
     // border
-    WX_STYLE_RESET_CSS_NODE(borderTopWidth, border[CSS_TOP], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(borderLeftWidth, border[CSS_LEFT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(borderRightWidth, border[CSS_RIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(borderBottomWidth, border[CSS_BOTTOM], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingStart, border[CSS_START], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingEnd, border[CSS_END], CSS_UNDEFINED)
     
     // padding
-    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_TOP], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_LEFT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingRight, padding[CSS_RIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_START], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_END], CSS_UNDEFINED)
 }
 
 - (void)_fillAbsolutePositions

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -77,6 +77,11 @@
     [self _fillCSSNode:styles];
 }
 
+-(void)_resetCSSNodeStyles:(NSArray *)styles
+{
+    [self _resetCSSNode:styles];
+}
+
 - (void)_recomputeCSSNodeChildren
 {
     _cssNode->children_count = (int)[self _childrenCountForLayout];
@@ -245,6 +250,55 @@ do {\
     WX_STYLE_FILL_CSS_NODE(paddingLeft, padding[CSS_LEFT], WXPixelType)
     WX_STYLE_FILL_CSS_NODE(paddingRight, padding[CSS_RIGHT], WXPixelType)
     WX_STYLE_FILL_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], WXPixelType)
+}
+
+
+
+#define WX_STYLE_RESET_CSS_NODE(key, cssProp, defaultValue)\
+do {\
+    if (styles && [styles containsObject:@#key]) {\
+        _cssNode->style.cssProp = defaultValue;\
+        [self setNeedsLayout];\
+    }\
+} while(0);
+
+- (void)_resetCSSNode:(NSArray *)styles;
+{
+    // flex
+    WX_STYLE_RESET_CSS_NODE(flexDirection, flex_direction, CSS_FLEX_DIRECTION_COLUMN)
+    WX_STYLE_RESET_CSS_NODE(alignItems, align_items, CSS_ALIGN_STRETCH)
+    
+    // position
+    WX_STYLE_RESET_CSS_NODE(top, position[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(left, position[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(right, position[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(bottom, position[CSS_BOTTOM], CSS_UNDEFINED)
+    
+    // dimension
+    WX_STYLE_RESET_CSS_NODE(width, dimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(height, dimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(minWidth, minDimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(minHeight, minDimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(maxWidth, maxDimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    
+    // margin
+    WX_STYLE_RESET_CSS_NODE(marginTop, margin[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginLeft, margin[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginRight, margin[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginBottom, margin[CSS_BOTTOM], CSS_UNDEFINED)
+    
+    // border
+    WX_STYLE_RESET_CSS_NODE(borderTopWidth, border[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderLeftWidth, border[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderRightWidth, border[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderBottomWidth, border[CSS_BOTTOM], CSS_UNDEFINED)
+    
+    // padding
+    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingRight, padding[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], CSS_UNDEFINED)
 }
 
 - (void)_fillAbsolutePositions

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -252,8 +252,6 @@ do {\
     WX_STYLE_FILL_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], WXPixelType)
 }
 
-
-
 #define WX_STYLE_RESET_CSS_NODE(key, cssProp, defaultValue)\
 do {\
     if (styles && [styles containsObject:@#key]) {\
@@ -262,41 +260,59 @@ do {\
     }\
 } while(0);
 
+#define WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(key, cssProp, defaultValue)\
+do {\
+    WX_STYLE_RESET_CSS_NODE(key, cssProp[CSS_TOP], defaultValue)\
+    WX_STYLE_RESET_CSS_NODE(key, cssProp[CSS_LEFT], defaultValue)\
+    WX_STYLE_RESET_CSS_NODE(key, cssProp[CSS_RIGHT], defaultValue)\
+    WX_STYLE_RESET_CSS_NODE(key, cssProp[CSS_BOTTOM], defaultValue)\
+} while(0);
+
 - (void)_resetCSSNode:(NSArray *)styles;
 {
     // flex
-    WX_STYLE_RESET_CSS_NODE(alignContent, align_items, CSS_ALIGN_STRETCH)
-    WX_STYLE_RESET_CSS_NODE(alignContent, align_content, CSS_ALIGN_FLEX_START)
-
+    WX_STYLE_RESET_CSS_NODE(flex, flex, 0.0)
     WX_STYLE_RESET_CSS_NODE(flexDirection, flex_direction, CSS_FLEX_DIRECTION_COLUMN)
-
-    // dimension
-    WX_STYLE_RESET_CSS_NODE(width, dimensions[CSS_WIDTH], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(height, dimensions[CSS_HEIGHT], CSS_UNDEFINED)
-    
-    WX_STYLE_RESET_CSS_NODE(minWidth, minDimensions[CSS_WIDTH], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(minHeight, minDimensions[CSS_HEIGHT], CSS_UNDEFINED)
-    
-    WX_STYLE_RESET_CSS_NODE(maxWidth, maxDimensions[CSS_WIDTH], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
-    
-    // position
+    WX_STYLE_RESET_CSS_NODE(alignItems, align_items, CSS_ALIGN_STRETCH)
+    WX_STYLE_RESET_CSS_NODE(alignSelf, align_self, CSS_ALIGN_AUTO)
+    WX_STYLE_RESET_CSS_NODE(flexWrap, flex_wrap, CSS_NOWRAP)
+    WX_STYLE_RESET_CSS_NODE(justifyContent, justify_content, CSS_JUSTIFY_FLEX_START)
+//
+//    // position
+    WX_STYLE_RESET_CSS_NODE(position, position_type, CSS_POSITION_RELATIVE)
     WX_STYLE_RESET_CSS_NODE(top, position[CSS_TOP], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(left, position[CSS_LEFT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(right, position[CSS_RIGHT], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(bottom, position[CSS_BOTTOM], CSS_UNDEFINED)
     
+    // dimension
+    WX_STYLE_RESET_CSS_NODE(width, dimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(height, dimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(minWidth, minDimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(minHeight, minDimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(maxWidth, maxDimensions[CSS_WIDTH], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
+    
     // margin
-    WX_STYLE_RESET_CSS_NODE(marginStart, margin[CSS_START], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginEnd, margin[CSS_END], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(margin, margin, CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginTop, margin[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginLeft, margin[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginRight, margin[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(marginBottom, margin[CSS_BOTTOM], CSS_UNDEFINED)
     
     // border
-    WX_STYLE_RESET_CSS_NODE(paddingStart, border[CSS_START], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingEnd, border[CSS_END], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(borderWidth, border, CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderTopWidth, border[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderLeftWidth, border[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderRightWidth, border[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(borderBottomWidth, border[CSS_BOTTOM], CSS_UNDEFINED)
     
     // padding
-    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_START], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_END], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(padding, padding, CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_TOP], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_LEFT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingRight, padding[CSS_RIGHT], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], CSS_UNDEFINED)
 }
 
 - (void)_fillAbsolutePositions

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -294,22 +294,25 @@ do {\
     WX_STYLE_RESET_CSS_NODE(maxHeight, maxDimensions[CSS_HEIGHT], CSS_UNDEFINED)
     
     // margin
-    WX_STYLE_RESET_CSS_NODE(marginTop, margin[CSS_TOP], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginLeft, margin[CSS_LEFT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginRight, margin[CSS_RIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(marginBottom, margin[CSS_BOTTOM], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(margin, margin, 0.0)
+    WX_STYLE_RESET_CSS_NODE(marginTop, margin[CSS_TOP], 0.0)
+    WX_STYLE_RESET_CSS_NODE(marginLeft, margin[CSS_LEFT], 0.0)
+    WX_STYLE_RESET_CSS_NODE(marginRight, margin[CSS_RIGHT], 0.0)
+    WX_STYLE_RESET_CSS_NODE(marginBottom, margin[CSS_BOTTOM], 0.0)
     
     // border
-    WX_STYLE_RESET_CSS_NODE(borderTopWidth, border[CSS_TOP], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(borderLeftWidth, border[CSS_LEFT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(borderRightWidth, border[CSS_RIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(borderBottomWidth, border[CSS_BOTTOM], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(borderWidth, border, 0.0)
+    WX_STYLE_RESET_CSS_NODE(borderTopWidth, border[CSS_TOP], 0.0)
+    WX_STYLE_RESET_CSS_NODE(borderLeftWidth, border[CSS_LEFT], 0.0)
+    WX_STYLE_RESET_CSS_NODE(borderRightWidth, border[CSS_RIGHT], 0.0)
+    WX_STYLE_RESET_CSS_NODE(borderBottomWidth, border[CSS_BOTTOM], 0.0)
     
     // padding
-    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_TOP], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_LEFT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingRight, padding[CSS_RIGHT], CSS_UNDEFINED)
-    WX_STYLE_RESET_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], CSS_UNDEFINED)
+    WX_STYLE_RESET_CSS_NODE_ALL_DIRECTION(padding, padding, 0.0)
+    WX_STYLE_RESET_CSS_NODE(paddingTop, padding[CSS_TOP], 0.0)
+    WX_STYLE_RESET_CSS_NODE(paddingLeft, padding[CSS_LEFT], 0.0)
+    WX_STYLE_RESET_CSS_NODE(paddingRight, padding[CSS_RIGHT], 0.0)
+    WX_STYLE_RESET_CSS_NODE(paddingBottom, padding[CSS_BOTTOM], 0.0)
 }
 
 - (void)_fillAbsolutePositions

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -277,8 +277,8 @@ do {\
     WX_STYLE_RESET_CSS_NODE(alignSelf, align_self, CSS_ALIGN_AUTO)
     WX_STYLE_RESET_CSS_NODE(flexWrap, flex_wrap, CSS_NOWRAP)
     WX_STYLE_RESET_CSS_NODE(justifyContent, justify_content, CSS_JUSTIFY_FLEX_START)
-//
-//    // position
+
+    // position
     WX_STYLE_RESET_CSS_NODE(position, position_type, CSS_POSITION_RELATIVE)
     WX_STYLE_RESET_CSS_NODE(top, position[CSS_TOP], CSS_UNDEFINED)
     WX_STYLE_RESET_CSS_NODE(left, position[CSS_LEFT], CSS_UNDEFINED)

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -265,7 +265,6 @@ do {\
 - (void)_resetCSSNode:(NSArray *)styles;
 {
     // flex
-    
     WX_STYLE_RESET_CSS_NODE(alignContent, align_items, CSS_ALIGN_STRETCH)
     WX_STYLE_RESET_CSS_NODE(alignContent, align_content, CSS_ALIGN_FLEX_START)
 

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -324,30 +324,17 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     return NO;
 }
 
--(NSDictionary *)fetchResetStyles:(NSDictionary *)styles
+-(void)styles:(NSDictionary *)styles normalStyles:(NSMutableDictionary *)normalStyles resetStyles:(NSMutableArray *)resetStyles
 {
-    NSMutableDictionary *resetStyles = [@{} mutableCopy];
     for (NSString *key in styles) {
         id value = [styles objectForKey:key];
         if([self isShouldReset:value]) {
-            [resetStyles setValue:styles[key] forKey:key];
+            [resetStyles addObject:key];
+        }else{
+            [normalStyles setObject:styles[key] forKey:key];
         }
     }
-    return resetStyles;
 }
-
--(NSDictionary *)fetchStyles:(NSDictionary *)styles
-{
-    NSMutableDictionary *normalStyles = [@{} mutableCopy];
-    for (NSString *key in styles) {
-        id value = [styles objectForKey:key];
-        if(![self isShouldReset:value]) {
-            [normalStyles setValue:styles[key] forKey:key];
-        }
-    }
-    return normalStyles;
-}
-
 
 - (void)updateStyles:(NSDictionary *)styles forComponent:(NSString *)ref
 {
@@ -357,8 +344,9 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     WXComponent *component = [_indexDict objectForKey:ref];
     WXAssertComponentExist(component);
     
-    NSDictionary *normalStyles = [[self fetchStyles:styles] mutableCopy];
-    NSDictionary *resetStyles = [[self fetchResetStyles:styles] mutableCopy];
+    NSMutableDictionary *normalStyles = [NSMutableDictionary new];
+    NSMutableArray *resetStyles = [NSMutableArray new];
+    [self styles:styles normalStyles:normalStyles resetStyles:resetStyles];
     [component _updateStylesOnComponentThread:normalStyles resetStyles:resetStyles];
     [self _addUITask:^{
         [component _updateStylesOnMainThread:normalStyles resetStyles:resetStyles];

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -324,7 +324,7 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     return NO;
 }
 
--(void)styles:(NSDictionary *)styles normalStyles:(NSMutableDictionary *)normalStyles resetStyles:(NSMutableArray *)resetStyles
+-(void)filterStyles:(NSDictionary *)styles normalStyles:(NSMutableDictionary *)normalStyles resetStyles:(NSMutableArray *)resetStyles
 {
     for (NSString *key in styles) {
         id value = [styles objectForKey:key];
@@ -346,7 +346,7 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     
     NSMutableDictionary *normalStyles = [NSMutableDictionary new];
     NSMutableArray *resetStyles = [NSMutableArray new];
-    [self styles:styles normalStyles:normalStyles resetStyles:resetStyles];
+    [self filterStyles:styles normalStyles:normalStyles resetStyles:resetStyles];
     [component _updateStylesOnComponentThread:normalStyles resetStyles:resetStyles];
     [self _addUITask:^{
         [component _updateStylesOnMainThread:normalStyles resetStyles:resetStyles];

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.h
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.h
@@ -289,7 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param elements The reset style's elements
  * @discussion It can be overrided to handle specific style reseting. The method is called on the main thread.
  **/
-- (void)resetStyles:(NSArray *)elements;
+- (void)resetStyles:(NSArray *)styles;
 
 /**
  * @abstract Called when component's attributes are updated

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
@@ -92,7 +92,6 @@
         [self _setupNavBarWithStyles:_styles attributes:_attributes];
         [self _initCSSNodeWithStyles:_styles];
         [self _initViewPropertyWithStyles:_styles];
-        [self _resetStyles:_styles];
         [self _handleBorders:styles isUpdating:NO];
     }
     
@@ -356,13 +355,13 @@
 
 #pragma mark Updating
 
-- (void)_updateStylesOnComponentThread:(NSDictionary *)styles resetStyles:(NSDictionary *)resetStyles
+- (void)_updateStylesOnComponentThread:(NSDictionary *)styles resetStyles:(NSMutableArray *)resetStyles
 {
     pthread_mutex_lock(&_propertyMutex);
     [_styles addEntriesFromDictionary:styles];
     pthread_mutex_unlock(&_propertyMutex);
     [self _updateCSSNodeStyles:styles];
-    [self configResetCSSNodeStyles:resetStyles];
+    [self _resetCSSNodeStyles:resetStyles];
 }
 
 - (void)_updateAttributesOnComponentThread:(NSDictionary *)attributes
@@ -386,7 +385,7 @@
     pthread_mutex_unlock(&_propertyMutex);
 }
 
-- (void)_updateStylesOnMainThread:(NSDictionary *)styles resetStyles:(NSDictionary *)resetStyles
+- (void)_updateStylesOnMainThread:(NSDictionary *)styles resetStyles:(NSMutableArray *)resetStyles
 {
     WXAssertMainThread();
     
@@ -395,7 +394,7 @@
     [self _handleBorders:styles isUpdating:YES];
     
     [self updateStyles:styles];
-    [self configResetStyles:resetStyles];
+    [self resetStyles:resetStyles];
 }
 
 - (void)_updateAttributesOnMainThread:(NSDictionary *)attributes
@@ -418,41 +417,7 @@
 }
 
 #pragma mark Reset
--(NSArray *)fetchResetElements:(NSDictionary *)styles
-{
-    NSMutableArray *elements = [@[] mutableCopy];
-    for (NSString *key in styles) {
-        [elements addObject:key];
-    }
-    return elements;
-}
-
--(void )configResetStyles:(NSDictionary *)styles
-{
-    NSArray *elements = [[self fetchResetElements:styles] mutableCopy];
-    [self resetStyles:elements];
-}
-
--(void )configResetCSSNodeStyles:(NSDictionary *)styles
-{
-    NSArray *elements = [[self fetchResetElements:styles] mutableCopy];
-    [self _resetCSSNodeStyles:elements];
-}
-
--(void)configDefaultCSSNode:(NSArray *)elements
-{
-    if ([elements containsObject:@"height"]) {
-        _cssNode->style.dimensions[CSS_HEIGHT] = NAN;
-        [self setNeedsLayout];
-    }
-}
-
-- (void)_resetCSSNodeStyles:(NSArray *)elements
-{
-    [self configDefaultCSSNode:elements];
-}
-
-- (void)resetStyles:(NSArray *)elements
+- (void)resetStyles:(NSArray *)styles
 {
     WXAssertMainThread();
 }

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
@@ -439,8 +439,17 @@
     [self _resetCSSNodeStyles:elements];
 }
 
+-(void)configDefaultCSSNode:(NSArray *)elements
+{
+    if ([elements containsObject:@"height"]) {
+        _cssNode->style.dimensions[CSS_HEIGHT] = NAN;
+    }
+    [self setNeedsLayout];
+}
+
 - (void)_resetCSSNodeStyles:(NSArray *)elements
 {
+    [self configDefaultCSSNode:elements];
 }
 
 - (void)resetStyles:(NSArray *)elements

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
@@ -443,8 +443,8 @@
 {
     if ([elements containsObject:@"height"]) {
         _cssNode->style.dimensions[CSS_HEIGHT] = NAN;
+        [self setNeedsLayout];
     }
-    [self setNeedsLayout];
 }
 
 - (void)_resetCSSNodeStyles:(NSArray *)elements

--- a/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.m
+++ b/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.m
@@ -90,17 +90,6 @@
 
 #pragma mark Private
 
-- (UIColor *) _fetchBackgroundColor:(id)value
-{
-    UIColor *color = [WXConvert UIColor:value];
-    if(self) {
-        if([value isKindOfClass:[NSString class]] && [@"" isEqualToString:[WXConvert NSString:value]]) {
-            color = [UIColor clearColor];
-        }
-    }
-    return color;
-}
-
 - (void)_initViewPropertyWithStyles:(NSDictionary *)styles
 {
     _backgroundColor = styles[@"backgroundColor"] ? [WXConvert UIColor:styles[@"backgroundColor"]] : [UIColor clearColor];
@@ -173,10 +162,10 @@
     }
 }
 
--(void)_resetStyles:(NSDictionary *)styles
+-(void)_resetStyles:(NSArray *)styles
 {
-    if (styles[@"backgroundColor"]) {
-        _backgroundColor = styles[@"backgroundColor"] ? [self _fetchBackgroundColor:styles[@"backgroundColor"]] : [UIColor clearColor];
+    if (styles && [styles containsObject:@"backgroundColor"]) {
+        _backgroundColor = [UIColor clearColor];
     }
 }
 


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->

样式改变的时候，高度不设置，采用fontsize的，和安卓，h5 统一