### PR TITLE
[html5] fix appear when scroller has a height bigger than view height.

### DIFF
--- a/html5/render/browser/base/component/index.js
+++ b/html5/render/browser/base/component/index.js
@@ -2,14 +2,48 @@
 
 import { extend } from '../../utils'
 import { ComponentManager } from '../../dom'
+import { isComponentAppear } from '../../dom/appearWatcher'
 import * as operate from './operate'
 import * as position from './position'
 import flexbox from './flexbox'
 import { makeImageLazy, fireLazyload } from './lazyload'
 
-function hasIntersection (rect, ctRect) {
-  return (rect.left < ctRect.right && rect.right > ctRect.left)
-    && (rect.top < ctRect.bottom && rect.bottom > ctRect.top)
+// function hasIntersection (rect, ctRect) {
+//   const iW = window.innerWidth
+//   const iH = window.innerHeight
+//   ctRect.right = ctRect.right > iW ? iW : ctRect.right
+//   ctRect.bottom = ctRect.bottom > iH ? iH : ctRect.bottom
+//   return (rect.left < ctRect.right && rect.right > ctRect.left)
+//     && (rect.top < ctRect.bottom && rect.bottom > ctRect.top)
+// }
+
+const appearEvts = ['appear', 'disappear']
+
+/**
+ * check whether a event is valid to dispatch.
+ * @param  {Component}      comp  the component that this event is to trigger on.
+ * @param  {string}  type   the event type.
+ * @return {Boolean}        is it valid to dispatch.
+ */
+function isEventValid (comp, type) {
+  // if a component has aleary triggered 'appear' event, then
+  // the 'appear' even† can't be triggered again utill the
+  // 'disappear' event triggered.
+  if (appearEvts.indexOf(type) <= -1) {
+    return true
+  }
+  if (comp._appear === undefined && type === 'disappear') {
+    return false
+  }
+  let res
+  if (comp._appear === undefined && type === 'appear') {
+    res = true
+  }
+  else {
+    res = type !== comp._appear
+  }
+  res && (comp._appear = type)
+  return res
 }
 
 export default function Component (data, nodeType) {
@@ -106,6 +140,9 @@ Component.prototype = {
   //     - bubbles
   //     - cancelable
   dispatchEvent (type, data, config) {
+    if (!isEventValid(this, type)) {
+      return
+    }
     const event = document.createEvent('HTMLEvents')
     config = config || {}
     event.initEvent(type, config.bubbles || false, config.cancelable || false)
@@ -130,13 +167,18 @@ Component.prototype = {
     }
     // trigger 'appear' event in the next tick.
     setTimeout(() => {
-      const rect = this.node.getBoundingClientRect()
-      const parent = this.getParentScroller()
-      const parentNode = parent
-        ? parent.node
-        : this.getRootContainer()
-      const ctRect = parentNode.getBoundingClientRect()
-      if (hasIntersection(rect, ctRect)) {
+      // const rect = this.node.getBoundingClientRect()
+      // const parent = this.getParentScroller()
+      // const parentNode = parent
+      //   ? parent.node
+      //   : this.getRootContainer()
+      // const ctRect = parentNode.getBoundingClientRect()
+      // const ctR = {}
+      // ; ['left', 'right', 'top', 'bottom'].forEach(attr => {
+      //   ctR[attr] = ctRect[attr]
+      // })
+
+      if (isComponentAppear(this)) {
         this.dispatchEvent('appear', { direction: '' })
       }
     }, 0)

--- a/html5/render/browser/base/component/index.js
+++ b/html5/render/browser/base/component/index.js
@@ -8,15 +8,6 @@ import * as position from './position'
 import flexbox from './flexbox'
 import { makeImageLazy, fireLazyload } from './lazyload'
 
-// function hasIntersection (rect, ctRect) {
-//   const iW = window.innerWidth
-//   const iH = window.innerHeight
-//   ctRect.right = ctRect.right > iW ? iW : ctRect.right
-//   ctRect.bottom = ctRect.bottom > iH ? iH : ctRect.bottom
-//   return (rect.left < ctRect.right && rect.right > ctRect.left)
-//     && (rect.top < ctRect.bottom && rect.bottom > ctRect.top)
-// }
-
 const appearEvts = ['appear', 'disappear']
 
 /**
@@ -167,17 +158,6 @@ Component.prototype = {
     }
     // trigger 'appear' event in the next tick.
     setTimeout(() => {
-      // const rect = this.node.getBoundingClientRect()
-      // const parent = this.getParentScroller()
-      // const parentNode = parent
-      //   ? parent.node
-      //   : this.getRootContainer()
-      // const ctRect = parentNode.getBoundingClientRect()
-      // const ctR = {}
-      // ; ['left', 'right', 'top', 'bottom'].forEach(attr => {
-      //   ctR[attr] = ctRect[attr]
-      // })
-
       if (isComponentAppear(this)) {
         this.dispatchEvent('appear', { direction: '' })
       }

--- a/html5/render/browser/dom/appearWatcher.js
+++ b/html5/render/browser/dom/appearWatcher.js
@@ -1,29 +1,10 @@
 'use strict'
 
-import { extend } from '../utils'
+import { throttle } from '../utils'
 
-const componentsInScroller = []
-const componentsOutOfScroller = []
+const watchedComponents = []
 let listened = false
-let direction = 'up'
 let scrollY = 0
-
-export function watchIfNeeded (component) {
-  if (needWatch(component)) {
-    if (component.isInScrollable()) {
-      componentsInScroller.push(component)
-    }
-    else {
-      componentsOutOfScroller.push(component)
-    }
-    if (!listened) {
-      listened = true
-      // const handler = throttle(onScroll, 25)
-      const handler = throttle(onScroll, 100)
-      window.addEventListener('scroll', handler, false)
-    }
-  }
-}
 
 function needWatch (component) {
   const events = component.data.event
@@ -35,116 +16,61 @@ function needWatch (component) {
   return false
 }
 
-function onScroll (e) {
-  // If the scroll event is dispatched from a scrollable component
-  // implemented through scrollerjs, then the appear/disappear events
-  // should be treated specially by handleScrollerScroll.
-  if (e.originalType === 'scrolling') {
-    handleScrollerScroll(e)
-  }
-  else {
-    handleWindowScroll()
-  }
-}
-
-function handleScrollerScroll (e) {
-  const cmps = componentsInScroller
-  const len = cmps.length
-  direction = e.direction
-  for (let i = 0; i < len; i++) {
-    const component = cmps[i]
-    const appear = isComponentInScrollerAppear(component)
-    if (appear && !component._appear) {
-      component._appear = true
-      fireEvent(component, 'appear')
-    }
-    else if (!appear && component._appear) {
-      component._appear = false
-      fireEvent(component, 'disappear')
+export function watchIfNeeded (component) {
+  if (needWatch(component)) {
+    watchedComponents.push(component)
+    if (!listened) {
+      listened = true
+      const handler = throttle(onScroll, 100)
+      window.addEventListener('scroll', handler, false)
     }
   }
 }
 
-function handleWindowScroll () {
-  const y = window.scrollY
-  direction = y >= scrollY ? 'up' : 'down'
-  scrollY = y
-
-  const len = componentsOutOfScroller.length
-  if (len === 0) {
-    return
-  }
-  for (let i = 0; i < len; i++) {
-    const component = componentsOutOfScroller[i]
-    const appear = isComponentInWindow(component)
-    if (appear && !component._appear) {
-      component._appear = true
-      fireEvent(component, 'appear')
-    }
-    else if (!appear && component._appear) {
-      component._appear = false
-      fireEvent(component, 'disappear')
-    }
-  }
-}
-
-function isComponentInScrollerAppear (component) {
-  let parentScroller = component._parentScroller
-  const cmpRect = component.node.getBoundingClientRect()
-  if (!isComponentInWindow(component)) {
-    return false
-  }
-  while (parentScroller) {
-    const parentRect = parentScroller.node.getBoundingClientRect()
-    if (!(cmpRect.right > parentRect.left
-        && cmpRect.left < parentRect.right
-        && cmpRect.bottom > parentRect.top
-        && cmpRect.top < parentRect.bottom)) {
-      return false
-    }
-    parentScroller = parentScroller._parentScroller
-  }
-  return true
-}
-
-function isComponentInWindow (component) {
+export function isComponentInWindow (component) {
   const rect = component.node.getBoundingClientRect()
   return rect.right > 0 && rect.left < window.innerWidth &&
          rect.bottom > 0 && rect.top < window.innerHeight
 }
 
-function fireEvent (component, type) {
-  const evt = document.createEvent('HTMLEvents')
-  const data = { direction: direction }
-  evt.initEvent(type, false, false)
-  evt.data = data
-  extend(evt, data)
-  component.node.dispatchEvent(evt)
+export function hasIntersection (rect, ctRect) {
+  return (rect.left < ctRect.right && rect.right > ctRect.left)
+    && (rect.top < ctRect.bottom && rect.bottom > ctRect.top)
 }
 
-function throttle (func, wait) {
-  let context, args, result
-  let timeout = null
-  let previous = 0
-  const later = function () {
-    previous = Date.now()
-    timeout = null
-    result = func.apply(context, args)
+export function isComponentAppear (component) {
+  // NOTE: no more support embeded scrollers.
+  const parentScroller = component.getParentScroller()
+  if (!parentScroller) {
+    return isComponentInWindow(component)
   }
-  return function () {
-    const now = Date.now()
-    const remaining = wait - (now - previous)
-    context = this
-    args = arguments
-    if (remaining <= 0) {
-      clearTimeout(timeout)
-      timeout = null
-      previous = now
-      result = func.apply(context, args)
+  return isComponentInWindow(component)
+    && hasIntersection(
+      component.node.getBoundingClientRect(),
+      parentScroller.node.getBoundingClientRect())
+}
+
+function onScroll (e) {
+  let direction
+  // NOTE: this condition strongly relies on the scroller's implementation.
+  if (e.originalType === 'scrolling') {
+    direction = e.direction
+  }
+  else {
+    // NOTE: only VERTICAL window scroll can be detected.
+    const y = window.scrollY
+    direction = y >= scrollY ? 'up' : 'down'
+    scrollY = y
+  }
+  const len = watchedComponents.length
+  for (let i = 0; i < len; i++) {
+    const component = watchedComponents[i]
+    const appear = isComponentAppear(component)
+    if (appear) {
+      component.dispatchEvent('appear', { direction })
     }
-    else if (!timeout) {
-      timeout = setTimeout(later, remaining)
+    else if (!appear) {
+      component.dispatchEvent('disappear', { direction })
     }
-    return result
   }
 }


### PR DESCRIPTION
fix appear's bug when inner scroller has no height specified.

case:

```html
<template>
  <div>
    <text>{{value}}</text>
    <scroller>
      <div class="container" repeat="{{(k, v) in itemList}}">
        <text class="thumb title" indexv="{{k}}" onappear="test(k)">{{v.title}}</text>
      </div>
    </scroller>
  </div>
</template>

<style>
  .container {flex-direction: row;}
  .thumb {width: 200; height: 500;}
  .title {flex: 1; color: #ff0000; font-size: 48; font-weight: bold; background-color: #eeeeee;}
</style>

<script>
  module.exports = {
    data: {
      itemList: [
        {itemId: '520421163634', title: 'title1'},
        {itemId: '522076777462', title: 'title2'}, 
        {itemId: '520421163634', title: 'title3'},
        {itemId: '522076777462', title: 'title4'}, 
        {itemId: '520421163634', title: 'title5'},
        {itemId: '522076777462', title: 'title6'}, 
      ],
    value:0
    },
    methods: {
      test: function (k, e) {
        console.log('appear:', k)
      }
    }
  }
</script>
```