### PR TITLE
* [doc] Fix image path in branch gh-pages

### DIFF
--- a/doc/advanced/how-it-works.html
+++ b/doc/advanced/how-it-works.html
@@ -1737,7 +1737,7 @@ bootstrap(&apos;@weex-component/main&apos;)
 <p><strong>Component</strong> is an element in the screen which have a certain view and behavior. It could be configured with some attributes and style properties, and could response user interactions. There are some common components like <code>&lt;div&gt;</code>, <code>&lt;text&gt;</code>, <code>&lt;image&gt;</code> etc.</p>
 <p><strong>Module</strong> is a set of APIs which could be called from JS Framework. Some of them also have to make async callbacks to JS Framework, for example: send HTTP request.</p>
 <p>During a Weex instance works, Native RenderEngine receives all kinds of module API calls from JS Framework. These calls will create or update components for view and use client-side features like <code>toast</code>. When a user interaction or module API callback happens, It will call <code>callJS()</code> from JS Framework. These jobs could walk through the Weex instance lifecycle till the instance is destroyed. As is shown in the architecture figure, H5 RenderEngine is a special RenderEngine with almost the same functions as native RenderEngines. </p>
-<p><img src="../gtms02.alicdn.com/tps/i2/TB1ootBMpXXXXXrXXXXwi60UVXX-596-397.png" alt="arch"><br>Weex Architecture </p>
+<p><img src="//gtms02.alicdn.com/tps/i2/TB1ootBMpXXXXXrXXXXwi60UVXX-596-397.png" alt="arch"><br>Weex Architecture </p>
 <h3 id="call-native-from-javascript">call native from javascript</h3>
 <pre><code>[JS Framework]
 &#x2193; callNative
@@ -1752,7 +1752,7 @@ user interactions
 &#x2193; callJS
 [JS Framework]
 </code></pre><h3 id="render-flow">Render Flow</h3>
-<p><img src="../gtms03.alicdn.com/tps/i3/TB1_SA4MXXXXXXGaXXXpZ8UVXXX-519-337.png" alt="render flow"><br>Weex Render Flow </p>
+<p><img src="//gtms03.alicdn.com/tps/i3/TB1_SA4MXXXXXXGaXXXpZ8UVXXX-519-337.png" alt="render flow"><br>Weex Render Flow </p>
 <ol>
 <li>Input is virtual dom.</li>
 <li><strong>Build Tree</strong>. Parse JSON data (virtual dom) to a Render Tree (RT).</li>

--- a/doc/advanced/integrate-to-ios.html
+++ b/doc/advanced/integrate-to-ios.html
@@ -1675,7 +1675,7 @@ contentLoaded(window,function(){
     pod &apos;WeexSDK&apos;, :path=&gt;&apos;./sdk/&apos;
 end
 </code></pre><p>You can get your <code>YourTarget</code> below</p>
-<p><img src="../img4.tbcdn.cn/L1/461/1/4d9f4d6a8441b44e4816c7778627824fb72c58de" alt="img"></p>
+<p><img src="//img4.tbcdn.cn/L1/461/1/4d9f4d6a8441b44e4816c7778627824fb72c58de" alt="img"></p>
 <p>Run pod install in current directory, for a while, .xcworkspace will be created.  At this point, the dependencies have been established.</p>
 <h4 id="3-init-weex-environment">3. Init Weex Environment</h4>
 <p>We are used to doing some initial tasks in appDelegate. Of course, there is no exception. You can do this in <code>didFinishLaunchingWithOptions</code> as follows.</p>

--- a/doc/how-to/preview-in-browser.html
+++ b/doc/how-to/preview-in-browser.html
@@ -1675,7 +1675,7 @@ contentLoaded(window,function(){
 </code></pre><p>If all work well, navigate to the path the xxx.we file you want to preview in, and type the command:</p>
 <pre><code>weex xxx.we
 </code></pre><p>A browser window will be opened automatically to display the page you want to preview:</p>
-<p><img src="../gtms02.alicdn.com/tps/i2/TB1y151LVXXXXXXaXXXoRYgWVXX-495-584.jpg" alt="preview page"></p>
+<p><img src="//gtms02.alicdn.com/tps/i2/TB1y151LVXXXXXXaXXXoRYgWVXX-495-584.jpg" alt="preview page"></p>
 
                                 
                                 </section>

--- a/doc/how-to/preview-in-playground-app.html
+++ b/doc/how-to/preview-in-playground-app.html
@@ -1667,10 +1667,10 @@ contentLoaded(window,function(){
 <li>Clone Weex from github <a href="https://github.com/alibaba/weex/" target="_blank"><code>https://github.com/alibaba/weex/</code></a></li>
 <li>Use Android Studio open Android Sample &#x3002;</li>
 <li>run Sample project.</li>
-<li>into Sample homePage&#xFF0C;you will see this picture<br><img src="../gtms01.alicdn.com/tps/i1/TB10Ox2MpXXXXXKXpXXA0gJJXXX-720-1280.png" alt="preview page"></li>
-<li>Click the icon to the top right of the page to enter the two-dimensional code scanning<br><img src="../gtms04.alicdn.com/tps/i4/TB1Ph05MpXXXXcHXXXX2YSA3pXX-540-960.jpg" alt=""></li>
+<li>into Sample homePage&#xFF0C;you will see this picture<br><img src="//gtms01.alicdn.com/tps/i1/TB10Ox2MpXXXXXKXpXXA0gJJXXX-720-1280.png" alt="preview page"></li>
+<li>Click the icon to the top right of the page to enter the two-dimensional code scanning<br><img src="//gtms04.alicdn.com/tps/i4/TB1Ph05MpXXXXcHXXXX2YSA3pXX-540-960.jpg" alt=""></li>
 <li>use<a href="https://github.com/alibaba/weex_toolchain/tree/master/toolkit/" target="_blank"><code>Weex-Toolkit</code></a>make .we to a     QR code </li>
-<li>you will see the page rended by Weex<br><img src="../gtms03.alicdn.com/tps/i3/TB1ehVLMpXXXXa.XVXX2YSA3pXX-540-960.jpg" alt=""></li>
+<li>you will see the page rended by Weex<br><img src="//gtms03.alicdn.com/tps/i3/TB1ehVLMpXXXXa.XVXX2YSA3pXX-540-960.jpg" alt=""></li>
 </ol>
 
                                 


### PR DESCRIPTION
Fix image path in `gh-pages` branch.

For example, image in the bottom of page [preview-in-browser.html](https://alibaba.github.io/weex/doc/how-to/preview-in-browser.html) is missing.