### PR TITLE
add targetqueue to clipboard

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXClipboardModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXClipboardModule.m
@@ -13,6 +13,10 @@
 WX_EXPORT_METHOD(@selector(setString:))
 WX_EXPORT_METHOD(@selector(getString:))
 
+- (dispatch_queue_t)targetExecuteQueue {
+    return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+}
+
 - (void)setString:(NSString *)content
 {
     UIPasteboard *clipboard = [UIPasteboard generalPasteboard];


### PR DESCRIPTION
#### bugfix
  1. Modify WXClipboardModule by dispatching to a default queue when using UIPasteboard to avoid blocking main queue under iOS10 & macOS Sierra.
