### PR TITLE
* [jsfm] create a global Weex object for each JS bundle scope instead of __weex_xxx__

### DIFF
--- a/html5/frameworks/legacy/app/ctrl/init.js
+++ b/html5/frameworks/legacy/app/ctrl/init.js
@@ -49,7 +49,7 @@ export function init (app, code, data) {
   /* istanbul ignore next */
   const bundleRequireModule = name => app.requireModule(removeWeexPrefix(name))
 
-  const Weex = {
+  const weexGlobalObject = {
     config: app.options,
     define: bundleDefine,
     bootstrap: bundleBootstrap,
@@ -58,7 +58,7 @@ export function init (app, code, data) {
     Vm: bundleVm
   }
 
-  Object.freeze(Weex)
+  Object.freeze(weexGlobalObject)
 
   // prepare code
   let functionBody
@@ -116,7 +116,7 @@ export function init (app, code, data) {
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
       '__weex_viewmodel__',
-      'Weex',
+      'weex',
       'setTimeout',
       'setInterval',
       'clearTimeout',
@@ -135,7 +135,7 @@ export function init (app, code, data) {
       bundleDocument,
       bundleRequireModule,
       bundleVm,
-      Weex,
+      weexGlobalObject,
       timerAPIs.setTimeout,
       timerAPIs.setInterval,
       timerAPIs.clearTimeout,
@@ -153,7 +153,7 @@ export function init (app, code, data) {
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
       '__weex_viewmodel__',
-      'Weex',
+      'weex',
       functionBody
     )
 
@@ -168,7 +168,7 @@ export function init (app, code, data) {
       bundleDocument,
       bundleRequireModule,
       bundleVm,
-      Weex)
+      weexGlobalObject)
   }
 
   return result

--- a/html5/frameworks/legacy/app/ctrl/init.js
+++ b/html5/frameworks/legacy/app/ctrl/init.js
@@ -49,6 +49,17 @@ export function init (app, code, data) {
   /* istanbul ignore next */
   const bundleRequireModule = name => app.requireModule(removeWeexPrefix(name))
 
+  const Weex = {
+    config: app.options,
+    define: bundleDefine,
+    bootstrap: bundleBootstrap,
+    require: bundleDocument,
+    document: bundleRequireModule,
+    Vm: bundleVm
+  }
+
+  Object.freeze(Weex)
+
   // prepare code
   let functionBody
   /* istanbul ignore if */
@@ -105,6 +116,7 @@ export function init (app, code, data) {
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
       '__weex_viewmodel__',
+      'Weex',
       'setTimeout',
       'setInterval',
       'clearTimeout',
@@ -123,6 +135,7 @@ export function init (app, code, data) {
       bundleDocument,
       bundleRequireModule,
       bundleVm,
+      Weex,
       timerAPIs.setTimeout,
       timerAPIs.setInterval,
       timerAPIs.clearTimeout,
@@ -140,6 +153,7 @@ export function init (app, code, data) {
       '__weex_document__', // alias for bootstrap
       '__weex_require__',
       '__weex_viewmodel__',
+      'Weex',
       functionBody
     )
 
@@ -153,7 +167,8 @@ export function init (app, code, data) {
       bundleBootstrap,
       bundleDocument,
       bundleRequireModule,
-      bundleVm)
+      bundleVm,
+      Weex)
   }
 
   return result

--- a/html5/test/case/basic/global-weex-object.output.js
+++ b/html5/test/case/basic/global-weex-object.output.js
@@ -1,0 +1,6 @@
+{
+    type: 'div',
+    attr: {
+        a: 'WeexDemo'
+    }
+}

--- a/html5/test/case/basic/global-weex-object.source.js
+++ b/html5/test/case/basic/global-weex-object.source.js
@@ -1,0 +1,19 @@
+Weex.define('@weex-component/foo', function (require, exports, module) {
+  module.exports = {
+    data: function () {
+      return {
+        x: Weex.config.env.appName
+      }
+    },
+    template: {
+      "type": "div",
+      "attr": {
+        "a": function () {
+          return this.x
+        }
+      }
+    }
+  }
+})
+
+Weex.bootstrap('@weex-component/foo')

--- a/html5/test/case/basic/global-weex-object.source.js
+++ b/html5/test/case/basic/global-weex-object.source.js
@@ -1,8 +1,8 @@
-Weex.define('@weex-component/foo', function (require, exports, module) {
+weex.define('@weex-component/foo', function (require, exports, module) {
   module.exports = {
     data: function () {
       return {
-        x: Weex.config.env.appName
+        x: weex.config.env.appName
       }
     },
     template: {
@@ -16,4 +16,4 @@ Weex.define('@weex-component/foo', function (require, exports, module) {
   }
 })
 
-Weex.bootstrap('@weex-component/foo')
+weex.bootstrap('@weex-component/foo')

--- a/html5/test/case/tester.js
+++ b/html5/test/case/tester.js
@@ -46,6 +46,8 @@ describe('test input and output', function () {
       app.$destroy()
     }
 
+    it('global Weex object', () => checkOutput(app, 'global-weex-object'))
+
     it('single case', () => checkOutput(app, 'foo'))
     it('foo2 case', () => checkOutput(app, 'foo2'))
     it('foo3 case', () => checkOutput(app, 'foo3'))


### PR DESCRIPTION
* `weex.config` === `this.$getConfig()`
* `weex.require('xxx')` === `__weex_require__('xxx')` === `require('@weex-module/xxx')`

And more low-level APIs
* `weex.define` === `__weex_define__`
* `weex.document` === `__weex_document__`
* `weex.bootstrap` === `__weex_bootstrap__`
* `weex.Vm` === `__weex_viewmodel__`

And they all work in both `*.we` files and `*.js` files