### PR TITLE
[html5] add playsinline by default for video

### DIFF
--- a/html5/render/browser/extend/components/video/index.js
+++ b/html5/render/browser/extend/components/video/index.js
@@ -11,6 +11,8 @@ function getProto (Weex) {
       node.classList.add('weex-element')
       node.controls = true
       node.autoplay = this.autoPlay
+      node.setAttribute('playsinline', '')
+      node.setAttribute('webkit-playsinline', '')
       node.setAttribute('play-status', this.playStatus)
       this.node = node
       if (this.autoPlay && this.playStatus === 'play') {


### PR DESCRIPTION
video tag add `playsinline` by default to prevent auto changing to fullscreen displaying.