### PR TITLE
[html5] fix uncaught dom exception for video.play.

### DIFF
--- a/html5/render/browser/extend/components/video/index.js
+++ b/html5/render/browser/extend/components/video/index.js
@@ -14,7 +14,11 @@ function getProto (Weex) {
       node.setAttribute('play-status', this.playStatus)
       this.node = node
       if (this.autoPlay && this.playStatus === 'play') {
-        this.play()
+        // set timer to avoid error: uncaught DOM exception: the play() request
+        // was interrupted by a new load request.
+        setTimeout(() => {
+          this.play()
+        }, 0)
       }
       return node
     },
@@ -41,7 +45,12 @@ function getProto (Weex) {
         src = this.node.getAttribute('data-src')
         src && this.node.setAttribute('src', src)
       }
-      this.node.play()
+      try {
+        this.node.play()
+      }
+      catch (err) {
+        // DO NOTHING.
+      }
     },
 
     pause () {


### PR DESCRIPTION
fix `uncaught (in promise) DOMException: The play() request was interrupted by a new load request.`