### PR TITLE
[jsfm] supported CSS units by global.CSS_UNIT

### DIFF
--- a/html5/runtime/init.js
+++ b/html5/runtime/init.js
@@ -120,6 +120,28 @@ function adaptInstance (methodName, nativeMethodName) {
 }
 
 export default function init (config) {
+  const env = global.WXEnvironment
+  if (env) {
+    const scale = 2 // 750 by default currently
+    // @todo: support viewport config
+    const units = {
+      REM: 12 * scale,
+      VW: env.deviceWidth / 100,
+      VH: env.deviceHeight / 100,
+      VMIN: Math.min(env.deviceWidth, env.deviceHeight) / 100,
+      VMAX: Math.max(env.deviceWidth, env.deviceHeight) / 100,
+      CM: 96 / 2.54 * scale,
+      MM: 96 / 25.4 * scale,
+      Q: 96 / 25.4 / 4 * scale,
+      IN: 96 * scale,
+      PT: 96 / 72 * scale,
+      PC: 96 / 6 * scale,
+      PX: scale
+    }
+    Object.freeze(units)
+    global.CSS_UNIT = units
+  }
+
   frameworks = config.frameworks || {}
 
   // Init each framework by `init` method and `config` which contains three

--- a/html5/test/case/basic/css-unit.output.js
+++ b/html5/test/case/basic/css-unit.output.js
@@ -1,0 +1,6 @@
+{
+    type: 'div',
+    style: {
+      width: 375
+    }
+}

--- a/html5/test/case/basic/css-unit.source.js
+++ b/html5/test/case/basic/css-unit.source.js
@@ -1,0 +1,10 @@
+define('@weex-component/css-unit', function (require, exports, module) {
+  module.exports.template = {
+    "type": "div",
+    "style": {
+      "width": 50 * CSS_UNIT.VW
+    }
+  }
+})
+
+bootstrap('@weex-component/css-unit')

--- a/html5/test/case/prepare.js
+++ b/html5/test/case/prepare.js
@@ -4,7 +4,9 @@ import path from 'path'
 // load test driver
 import {
   Runtime,
-  Instance
+  Instance,
+  DEFAULT_ENV,
+  DEFAULT_CSS_UNIT
 } from 'weex-vdom-tester'
 
 // load env
@@ -26,6 +28,9 @@ global.callNativeHandler = function () {}
 global.callAddElement = function (id, ref, json, index) {
   return callNativeHandler(id, [{ module: 'dom', method: 'addElement', args: [ref, json, index] }])
 }
+
+global.WXEnvironment = DEFAULT_ENV
+global.CSS_UNIT = DEFAULT_CSS_UNIT
 
 // create test driver runtime
 export function createRuntime () {

--- a/html5/test/case/tester.js
+++ b/html5/test/case/tester.js
@@ -81,6 +81,7 @@ describe('test input and output', function () {
     it('repeat watch case', () => checkOutput(app, 'repeat-watch'))
 
     it('reset style case', () => checkOutput(app, 'reset-style'))
+    it('CSS unit case', () => checkOutput(app, 'css-unit'))
     it('dynamic type case', () => checkOutput(app, 'dynamic-type'))
     it('dynamic property case', () => checkOutput(app, 'dynamic-property'))
 

--- a/html5/test/unit/default/runtime.js
+++ b/html5/test/unit/default/runtime.js
@@ -17,7 +17,22 @@ runtime.setNativeConsole()
 import Vm from '../../../frameworks/legacy/vm'
 import { clearModules, getModule } from '../../../frameworks/legacy/app/register'
 
+const testingEnv = {
+  scale: 2,
+  appVersion: '1.8.3',
+  deviceModel: 'x86_64',
+  appName: 'WeexDemo',
+  platform: 'iOS',
+  osVersion: '9.3',
+  weexVersion: '0.7.0',
+  deviceHeight: 1334,
+  logLevel: 'log',
+  deviceWidth: 750
+}
+const oriEnv = global.WXEnvironment
+global.WXEnvironment = testingEnv
 const framework = init(config)
+global.WXEnvironment = oriEnv
 
 function clearRefs (json) {
   delete json.ref

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "webpack": "^1.13.1",
     "weex-components": "^0.2.0",
     "weex-loader": "^0.3.1",
-    "weex-vdom-tester": "^0.1.2",
+    "weex-vdom-tester": "^0.1.4",
     "weex-vue-loader": "^0.1.2",
     "wwp": "^0.3.0"
   }


### PR DESCRIPTION
Support more CSS units without native update.

Three updates together:

1. `css-units` branch in `weexteam/weex-styler`
2. `weex-next` branch in `weexteam/weex-vue-loader`
3. `jsfm-feature-css-units` in `jinjiang/weex`

How it works: CSS value `100rem` in `<style>` will be transformed into `"100rem"` by `weex-styler` and then `100 * CSS_UNIT.REM` by `weex-vue-loader`. At the same time define global variable `CSS_UNIT` in JS Framework. So it works.