### PR TITLE
Ios feature 20170118 slider onscroll

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
@@ -18,6 +18,7 @@
 
 @protocol WXSliderViewDelegate <UIScrollViewDelegate>
 
+- (void)sliderView:(WXSliderView *)sliderView sliderViewDidScroll:(UIScrollView *)scrollView;
 - (void)sliderView:(WXSliderView *)sliderView didScrollToItemAtIndex:(NSInteger)index;
 
 @end
@@ -263,6 +264,9 @@
     if (itemView) {
         self.currentIndex = itemView.tag;
     }
+    if (self.delegate && [self.delegate respondsToSelector:@selector(sliderView:sliderViewDidScroll:)]) {
+        [self.delegate sliderView:self sliderViewDidScroll:self.scrollView];
+    }
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
@@ -289,7 +293,10 @@
 @property (nonatomic, assign) BOOL  autoPlay;
 @property (nonatomic, assign) NSUInteger interval;
 @property (nonatomic, assign) NSInteger index;
+@property (nonatomic, assign) CGFloat lastXDeviationPercent;
+@property (nonatomic, assign) CGFloat scrollAccuracy;
 @property (nonatomic, assign) BOOL  sliderChangeEvent;
+@property (nonatomic, assign) BOOL  sliderScrollEvent;
 @property (nonatomic, strong) NSMutableArray *childrenView;
 
 @end
@@ -305,8 +312,10 @@
 {
     if (self = [super initWithRef:ref type:type styles:styles attributes:attributes events:events weexInstance:weexInstance]) {
         _sliderChangeEvent = NO;
+        _sliderScrollEvent = NO;
         _interval = 3000;
         _childrenView = [NSMutableArray new];
+        _lastXDeviationPercent = 0;
         
         if (attributes[@"autoPlay"]) {
             _autoPlay = [attributes[@"autoPlay"] boolValue];
@@ -318,6 +327,10 @@
         
         if (attributes[@"index"]) {
             _index = [attributes[@"index"] integerValue];
+        }
+        
+        if (attributes[@"xDeviationAccuracy"]) {
+            _scrollAccuracy = [WXConvert CGFloat:attributes[@"xDeviationAccuracy"]];
         }
         
         self.cssNode->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
@@ -444,6 +457,10 @@
         self.currentIndex = _index;
         [_sliderView scroll2ItemView:self.currentIndex animated:YES];
     }
+    
+    if (attributes[@"xDeviationAccuracy"]) {
+        _scrollAccuracy = [WXConvert CGFloat:attributes[@"xDeviationAccuracy"]];
+    }
 }
 
 - (void)addEvent:(NSString *)eventName
@@ -451,12 +468,18 @@
     if ([eventName isEqualToString:@"change"]) {
         _sliderChangeEvent = YES;
     }
+    if ([eventName isEqualToString:@"scroll"]) {
+        _sliderScrollEvent = YES;
+    }
 }
 
 - (void)removeEvent:(NSString *)eventName
 {
     if ([eventName isEqualToString:@"change"]) {
         _sliderChangeEvent = NO;
+    }
+    if ([eventName isEqualToString:@"scroll"]) {
+        _sliderScrollEvent = NO;
     }
 }
 
@@ -509,10 +532,24 @@
     }
 }
 
+#pragma mark ScrollView Delegate
+
+- (void)sliderView:(WXSliderView *)sliderView sliderViewDidScroll:(UIScrollView *)scrollView
+{
+    if (_sliderScrollEvent) {
+        CGFloat width = scrollView.frame.size.width;
+        CGFloat XDeviation = scrollView.frame.origin.x - (scrollView.contentOffset.x - width);
+        CGFloat XDeviationPercent = (XDeviation / width);
+        if (ABS(XDeviationPercent - _lastXDeviationPercent) >= _scrollAccuracy) {
+            _lastXDeviationPercent = XDeviationPercent;
+            [self fireEvent:@"scroll" params:@{@"XDeviationPercent":[NSNumber numberWithFloat:XDeviationPercent]} domChanges:nil];
+        }
+    }
+}
+
 - (void)sliderView:(WXSliderView *)sliderView didScrollToItemAtIndex:(NSInteger)index
 {
     self.currentIndex = index;
-    
     if (_sliderChangeEvent) {
         [self fireEvent:@"change" params:@{@"index":@(index)} domChanges:@{@"attrs": @{@"index": @(index)}}];
     }


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->
测试demo:http://weex.alibaba-inc.com/playground/fe233c18bb0bd24b2dfe7076c772eff7
解决方案：
scroll过程中通过onscroll事件回调，传回x轴偏移比例。前端监听onscroll事件，并设置精度值：0--1之间。native端判断偏移比例超过精度就进行一次回调。比如：精度0.1，正常会回调8或9次。scroll达到page宽度时，可能不回调。所以前端要监听onchange事件，保证currentPage值正确。