### PR TITLE
[html5] support 'load' event and naturalWidth & naturalHeight in ev…

### DIFF
--- a/html5/render/browser/extend/components/image/index.js
+++ b/html5/render/browser/extend/components/image/index.js
@@ -8,6 +8,8 @@ const DEFAULT_SIZE = 200
 const RESIZE_MODES = ['stretch', 'cover', 'contain']
 const DEFAULT_RESIZE_MODE = 'stretch'
 
+let Atomic
+
 /**
  * resize: 'cover' | 'contain' | 'stretch', default is 'stretch'
  * src: url
@@ -73,8 +75,19 @@ const style = {
   }
 }
 
+const event = {
+  load: {
+    extra: function () {
+      const { naturalWidth, naturalHeight } = this.node
+      return {
+        naturalWidth, naturalHeight
+      }
+    }
+  }
+}
+
 function init (Weex) {
-  const Atomic = Weex.Atomic
+  Atomic = Weex.Atomic
   const extend = Weex.utils.extend
 
   function Image (data) {
@@ -87,6 +100,7 @@ function init (Weex) {
   extend(Image.prototype, {
     style: extend(Object.create(Atomic.prototype.style), style)
   })
+  extend(Image.prototype, { event })
 
   Weex.registerComponent('image', Image)
 }

--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
     "cubicbezier": "^0.1.1",
     "envd": "^0.1.1",
     "httpurl": "^0.1.1",
-    "lazyimg": "^0.1.3",
+    "lazyimg": "^0.1.5",
     "modals": "^0.1.6",
     "scroll-to": "0.0.2",
     "semver": "^5.1.0",
-    "weex-vue-framework": "2.0.5-weex.1",
-    "weex-components": "^0.2.0"
+    "weex-components": "^0.2.0",
+    "weex-vue-framework": "2.0.5-weex.1"
   },
   "devDependencies": {
     "babel-core": "^6.17.0",


### PR DESCRIPTION
* `<image>` support `load` event
* through the event object, developers can access`naturalWidth` and `naturalHeight` to get the original width and height of the loaded image.

use case:

```html
<template>
  <div><image src="..." onload="handleLoad"></image></div>
</template>

<script>
module.exports = {
  methods: {
    handleLoad: function (e) {
      console.log('load!' + ' size: ' + e.naturalWidth + ',' + e.naturalHeight)
    }
  }
}
</script>
```
