### PR TITLE
[html5] fix content-type error

### DIFF
--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -6,6 +6,7 @@
 let utils
 
 import 'httpurl'
+import qs from 'query-string'
 
 let jsonpCnt = 0
 const ERROR_STATE = -1
@@ -216,21 +217,20 @@ const stream = {
       return console.error('[h5-render] options.url should be set for \'fetch\' API.')
     }
 
-    // valide body content for method 'GET'.
+    // validate body content for method 'GET'.
     if (config.method.toUpperCase() === 'GET') {
-      const body = config.body
-      if (body) {
-        try {
-          const url = lib.httpurl(config.url)
-          Object.keys(body).forEach(key => {
-            url.params[key] = body[key]
-          })
-          config.url = url.toString().replace(/^http:/, '')
-        }
-        catch (e) {
-          console.warn('[h5-render] invalid url:', config.url)
-        }
+      let body = config.body
+      if (utils.isPlainObject(body)) {
+        body = qs.stringify(body)
       }
+      let url = config.url
+      let hashIdx = url.indexOf('#')
+      hashIdx <= -1 && (hashIdx = url.length)
+      let hash = url.substr(hashIdx)
+      hash && (hash = '#' + hash)
+      url = url.substring(0, hashIdx)
+      url += (config.url.indexOf('?') <= -1 ? '?' : '&') + body + hash
+      config.url = url
     }
 
     // validate options.mode

--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -251,24 +251,6 @@ const stream = {
       return console.error('[h5-render] options.headers should be a plain object')
     }
 
-    // validate options.body
-    const body = config.body
-    if (!config.headers['Content-Type'] && body) {
-      if (utils.isPlainObject(body)) {
-        // is a json data
-        try {
-          config.body = JSON.stringify(body)
-          config.headers['Content-Type'] = TYPE_JSON
-        }
-        catch (e) {}
-      }
-      else if (utils.getType(body) === 'string' && body.match(REG_FORM)) {
-        // is form-data
-        config.body = encodeURI(body)
-        config.headers['Content-Type'] = TYPE_FORM
-      }
-    }
-
     // validate options.timeout
     config.timeout = parseInt(config.timeout, 10) || 2500
 

--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -10,11 +10,6 @@ import 'httpurl'
 let jsonpCnt = 0
 const ERROR_STATE = -1
 
-const TYPE_JSON = 'application/json;charset=UTF-8'
-const TYPE_FORM = 'application/x-www-form-urlencoded'
-
-const REG_FORM = /^(?:[^&=]+=[^&=]+)(?:&[^&=]+=[^&=]+)*$/
-
 function _jsonp (config, callback, progressCallback) {
   const cbName = 'jsonp_' + (++jsonpCnt)
   let url
@@ -219,6 +214,23 @@ const stream = {
     // validate options.url
     if (!config.url) {
       return console.error('[h5-render] options.url should be set for \'fetch\' API.')
+    }
+
+    // valide body content for method 'GET'.
+    if (config.method.toUpperCase() === 'GET') {
+      const body = config.body
+      if (body) {
+        try {
+          const url = lib.httpurl(config.url)
+          Object.keys(body).forEach(key => {
+            url.params[key] = body[key]
+          })
+          config.url = url.toString().replace(/^http:/, '')
+        }
+        catch (e) {
+          console.warn('[h5-render] invalid url:', config.url)
+        }
+      }
     }
 
     // validate options.mode

--- a/package.json
+++ b/package.json
@@ -72,10 +72,11 @@
     "httpurl": "^0.1.1",
     "lazyimg": "^0.1.3",
     "modals": "^0.1.6",
+    "query-string": "^4.2.3",
     "scroll-to": "0.0.2",
     "semver": "^5.1.0",
-    "weex-vue-framework": "2.0.5-weex.1",
-    "weex-components": "^0.2.0"
+    "weex-components": "^0.2.0",
+    "weex-vue-framework": "2.0.5-weex.1"
   },
   "devDependencies": {
     "babel-core": "^6.17.0",


### PR DESCRIPTION
Leave `content-type` for developer to set since the content-type is not always supported by services and there's no need to deduce the content-type from the body data.