### PR TITLE
[html5] keep alive for global event listeners.

### DIFF
--- a/html5/render/browser/extend/api/globalEvent.js
+++ b/html5/render/browser/extend/api/globalEvent.js
@@ -10,7 +10,7 @@ const globalEvent = {
    * @param {string} evt - the event name to add a listener on.
    */
   addEventListener (evt, callbackId) {
-    const cb = e => this.sender.performCallback(callbackId, e)
+    const cb = e => this.sender.performCallback(callbackId, e, true)
     if (!handlerTraker[evt]) {
       handlerTraker[evt] = [cb]
     }


### PR DESCRIPTION
add `keepAlive=true` when calling the callback for `globalEvent.addEventListener`.