### PR TITLE
Ios bugfix sticky and slider neighbor

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -215,9 +215,9 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     }
     CGFloat scrollOffsetY = ((UIScrollView *)self.view).contentOffset.y;
     for(WXComponent *component in self.stickyArray) {
-//        if (CGPointEqualToPoint(component->_absolutePosition, CGPointZero)) {
-//            component->_absolutePosition = [component.supercomponent.view convertPoint:component.view.frame.origin toView:self.view];
-//        }
+        if (CGPointEqualToPoint(component->_absolutePosition, CGPointZero)) {
+            component->_absolutePosition = [component.supercomponent.view convertPoint:component.view.frame.origin toView:self.view];
+        }
         CGPoint relativePosition = component->_absolutePosition;
         if (isnan(relativePosition.y)) {
             continue;

--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -215,9 +215,9 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     }
     CGFloat scrollOffsetY = ((UIScrollView *)self.view).contentOffset.y;
     for(WXComponent *component in self.stickyArray) {
-        if (CGPointEqualToPoint(component->_absolutePosition, CGPointZero)) {
-            component->_absolutePosition = [component.supercomponent.view convertPoint:component.view.frame.origin toView:self.view];
-        }
+//        if (CGPointEqualToPoint(component->_absolutePosition, CGPointZero)) {
+//            component->_absolutePosition = [component.supercomponent.view convertPoint:component.view.frame.origin toView:self.view];
+//        }
         CGPoint relativePosition = component->_absolutePosition;
         if (isnan(relativePosition.y)) {
             continue;

--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderNeighborComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderNeighborComponent.m
@@ -74,7 +74,6 @@
 @property (nonatomic, assign) NSInteger previousItemIndex;
 @property (nonatomic, readonly) CGFloat itemWidth;
 @property (nonatomic, assign) BOOL inited;
-@property (nonatomic, assign) BOOL panInvertical;
 @end
 
 @implementation WXSliderNeighborView
@@ -552,16 +551,12 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
         {
             case UIGestureRecognizerStateBegan:
             {
-                if (self.panInvertical) {
-                    break;
-                }
+       
                 _dragging = YES;
                 _scrolling = NO;
                 _decelerating = NO;
                 _previousTranslation = _vertical? [panGesture translationInView:self].y: [panGesture translationInView:self].x;
-                if (self.panInvertical) {
-                    break;
-                }
+        
                 [_delegate sliderNeighborWillBeginDragging:self];
                 break;
             }
@@ -573,9 +568,7 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
             case UIGestureRecognizerStateCancelled:
             case UIGestureRecognizerStateFailed:
             {
-                if (self.panInvertical) {
-                    break;
-                }
+          
                 _dragging = NO;
                 _didDrag = YES;
                 if ([self shouldDecelerate]) {
@@ -608,9 +601,7 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
             }
             case UIGestureRecognizerStateChanged:
             {
-                if (self.panInvertical) {
-                    break;
-                }
+             
                 CGFloat translation = _vertical? [panGesture translationInView:self].y: [panGesture translationInView:self].x;
                 CGFloat velocity = _vertical? [panGesture velocityInView:self].y: [panGesture velocityInView:self].x;
                 
@@ -629,7 +620,6 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
             case UIGestureRecognizerStatePossible:
             {
                 //do nothing
-                self.panInvertical = NO;
                 break;
             }
         }

--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderNeighborComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderNeighborComponent.m
@@ -551,7 +551,6 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
         {
             case UIGestureRecognizerStateBegan:
             {
-       
                 _dragging = YES;
                 _scrolling = NO;
                 _decelerating = NO;
@@ -561,14 +560,10 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
                 break;
             }
             case UIGestureRecognizerStateEnded:
-//            {
-//                self.panInvertical = NO;
-//                break;
-//            }
+
             case UIGestureRecognizerStateCancelled:
             case UIGestureRecognizerStateFailed:
             {
-          
                 _dragging = NO;
                 _didDrag = YES;
                 if ([self shouldDecelerate]) {

--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderNeighborComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderNeighborComponent.m
@@ -474,18 +474,6 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
     return [self viewOrSuperview:view.superview ofClass:class];
 }
 
--(id)viewInChain:(UIView *)view ofClass:(Class)class{
-    if ([view isKindOfClass:class]) {
-        return view;
-    }
-    
-    if (view.superview) {
-        return [self viewOrSuperview:view.superview ofClass:class];
-    }
-    return nil;
-
-}
-
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gesture shouldReceiveTouch:(UITouch *)touch
 {
     if (_scrollEnabled) {
@@ -527,14 +515,14 @@ NSComparisonResult sliderNeighorCompareViewDepth(UIView *view1, UIView *view2, W
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer{
+   //if the view which the otherGestureRecognizer works on is a scrollview and also it is scrollEnabled vertically ,at this time,we should not block the guesture from being recognized by the otherGestureRecognize
     if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && [otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
         if ([otherGestureRecognizer.view isKindOfClass:[UIScrollView class]]) {
             UIScrollView* scrollview = (UIScrollView *)otherGestureRecognizer.view;
             if (scrollview.scrollEnabled) {
                 UIPanGestureRecognizer* panRcgn= (UIPanGestureRecognizer *)gestureRecognizer;
+                //check offset for confirming vertival movement
                 if (fabs([panRcgn translationInView:panRcgn.view].y) > fabs([panRcgn translationInView:panRcgn.view].x)*16) {
-//                    self.scrollEnabled = NO;
-//                    self.panInvertical = YES;
                     return YES;
                 }
             }


### PR DESCRIPTION
fix attribute ‘sticky’ bug while scrolling up and down quickly && and SliderNeighbor component’s guesture-blocking bug when it is used in a scrollview
