### PR TITLE
+ [ios] weex sdk support font weight when DSL set font weight

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -67,7 +67,7 @@
 //style
 @property (nonatomic) WXPixelType fontSize;
 @property (nonatomic) WXTextStyle fontStyle;
-@property (nonatomic) WXTextWeight fontWeight;
+@property (nonatomic) CGFloat fontWeight;
 @property (nonatomic, strong) NSString *fontFamily;
 @property (nonatomic, strong) UIColor *color;
 @property (nonatomic) NSTextAlignment textAlign;

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -105,7 +105,7 @@
     UIColor *_color;
     NSString *_fontFamily;
     CGFloat _fontSize;
-    WXTextWeight _fontWeight;
+    CGFloat _fontWeight;
     WXTextStyle _fontStyle;
     NSUInteger _lines;
     NSTextAlignment _textAlign;

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -61,7 +61,7 @@
 //style
 @property (nonatomic) WXPixelType fontSize;
 @property (nonatomic) WXTextStyle fontStyle;
-@property (nonatomic) WXTextWeight fontWeight;
+@property (nonatomic) CGFloat fontWeight;
 @property (nonatomic, strong) NSString *fontFamily;
 @property (nonatomic, copy) NSString *inputType;
 

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
@@ -48,6 +48,7 @@ typedef BOOL WXClipType;
  * @abstract UIFontWeightRegular ,UIFontWeightBold,etc are not support by the system which is less than 8.2. weex sdk set the float value.
  *
  * @param value, support normal,blod,100,200,300,400,500,600,700,800,900
+ *
  * @return A float value.
  *
  */

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
@@ -48,6 +48,7 @@ typedef BOOL WXClipType;
  * @abstract UIFontWeightRegular ,UIFontWeightBold,etc are not support by the system which is less than 8.2. weex sdk set the float value.
  *
  * @param value, support normal,blod,100,200,300,400,500,600,700,800,900
+ * @return A float value.
  *
  */
 + (CGFloat)WXTextWeight:(id)value;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
@@ -44,7 +44,13 @@ typedef BOOL WXClipType;
 + (WXPositionType)WXPositionType:(id)value;
 
 + (WXTextStyle)WXTextStyle:(id)value;
-+ (WXTextWeight)WXTextWeight:(id)value;
+/**
+ * @abstract UIFontWeightRegular ,UIFontWeightBold,etc are not support by the system which is less than 8.2. weex sdk set the float value.
+ *
+ * @param value, support normal,blod,100,200,300,400,500,600,700,800,900
+ *
+ */
++ (CGFloat)WXTextWeight:(id)value;
 + (WXTextDecoration)WXTextDecoration:(id)value;
 + (NSTextAlignment)NSTextAlignment:(id)value;
 

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -483,11 +483,30 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
     if([value isKindOfClass:[NSString class]]){
         NSString *string = (NSString *)value;
         if ([string isEqualToString:@"normal"])
-            return WXTextWeightNormal;
+            return WXFontWeightRegular;
         else if ([string isEqualToString:@"bold"])
-            return WXTextWeightBold;
+            return WXFontWeightBold;
+        else if ([string isEqualToString:@"100"])
+            return WXFontWeightUltraLight;
+        else if ([string isEqualToString:@"200"])
+            return WXFontWeightThin;
+        else if ([string isEqualToString:@"300"])
+            return WXFontWeightLight;
+        else if ([string isEqualToString:@"400"])
+            return WXFontWeightRegular;
+        else if ([string isEqualToString:@"500"])
+            return WXFontWeightMedium;
+        else if ([string isEqualToString:@"600"])
+            return WXFontWeightSemibold;
+        else if ([string isEqualToString:@"700"])
+            return WXFontWeightBold;
+        else if ([string isEqualToString:@"800"])
+            return WXFontWeightHeavy;
+        else if ([string isEqualToString:@"900"])
+            return WXFontWeightBlack;
+
     }
-    return WXTextWeightNormal;
+    return WXFontWeightRegular;
 }
 
 + (WXTextDecoration)WXTextDecoration:(id)value

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -478,7 +478,7 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
     return WXTextStyleNormal;
 }
 
-+ (CGFloat )WXTextWeight:(id)value
++ (CGFloat)WXTextWeight:(id)value
 {
     if([value isKindOfClass:[NSString class]]){
         NSString *string = (NSString *)value;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -478,35 +478,35 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
     return WXTextStyleNormal;
 }
 
-+ (WXTextWeight)WXTextWeight:(id)value
++ (CGFloat )WXTextWeight:(id)value
 {
     if([value isKindOfClass:[NSString class]]){
         NSString *string = (NSString *)value;
         if ([string isEqualToString:@"normal"])
-            return WXFontWeightRegular;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0:UIFontWeightRegular;
         else if ([string isEqualToString:@"bold"])
-            return WXFontWeightBold;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0.4:UIFontWeightBold;
         else if ([string isEqualToString:@"100"])
-            return WXFontWeightUltraLight;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?-0.8:UIFontWeightUltraLight;
         else if ([string isEqualToString:@"200"])
-            return WXFontWeightThin;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?-0.6:UIFontWeightThin;
         else if ([string isEqualToString:@"300"])
-            return WXFontWeightLight;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?-0.4:UIFontWeightLight;
         else if ([string isEqualToString:@"400"])
-            return WXFontWeightRegular;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0:UIFontWeightRegular;
         else if ([string isEqualToString:@"500"])
-            return WXFontWeightMedium;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0.23:UIFontWeightMedium;
         else if ([string isEqualToString:@"600"])
-            return WXFontWeightSemibold;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0.3:UIFontWeightSemibold;
         else if ([string isEqualToString:@"700"])
-            return WXFontWeightBold;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0.4:UIFontWeightBold;
         else if ([string isEqualToString:@"800"])
-            return WXFontWeightHeavy;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0.56:UIFontWeightHeavy;
         else if ([string isEqualToString:@"900"])
-            return WXFontWeightBlack;
+            return WX_SYS_VERSION_LESS_THAN(@"8.2")?0.62:UIFontWeightBlack;
 
     }
-    return WXFontWeightRegular;
+    return WX_SYS_VERSION_LESS_THAN(@"8.2")?0:UIFontWeightRegular;
 }
 
 + (WXTextDecoration)WXTextDecoration:(id)value

--- a/ios/sdk/WeexSDK/Sources/Utility/WXType.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXType.h
@@ -20,19 +20,6 @@ typedef NS_ENUM(NSUInteger, WXTextStyle) {
     WXTextStyleItalic
 };
 
-typedef NS_ENUM(NSUInteger, WXTextWeight) {
-    WXFontWeightRegular = 0,
-    WXFontWeightUltraLight,
-    WXFontWeightThin,
-    WXFontWeightLight,
-    WXFontWeightMedium,
-    WXFontWeightSemibold,
-    WXFontWeightBold,
-    WXFontWeightHeavy,
-    WXFontWeightBlack
-
-};
-
 typedef NS_ENUM(NSInteger, WXTextDecoration) {
     WXTextDecorationNone = 0,
     WXTextDecorationUnderline,

--- a/ios/sdk/WeexSDK/Sources/Utility/WXType.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXType.h
@@ -21,8 +21,16 @@ typedef NS_ENUM(NSUInteger, WXTextStyle) {
 };
 
 typedef NS_ENUM(NSUInteger, WXTextWeight) {
-    WXTextWeightNormal = 0,
-    WXTextWeightBold,
+    WXFontWeightRegular = 0,
+    WXFontWeightUltraLight,
+    WXFontWeightThin,
+    WXFontWeightLight,
+    WXFontWeightMedium,
+    WXFontWeightSemibold,
+    WXFontWeightBold,
+    WXFontWeightHeavy,
+    WXFontWeightBlack
+
 };
 
 typedef NS_ENUM(NSInteger, WXTextDecoration) {

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.h
@@ -202,7 +202,7 @@ extern _Nonnull SEL WXSwizzledSelectorForSelector(_Nonnull SEL selector);
  *
  * @param textSize.
  *
- * @param textWeight. The type of WXTextWeight (Normal or Bold).
+ * @param textWeight.
  *
  * @param textStyle. The type of WXTextStyle (Normal or Italic).
  *
@@ -211,7 +211,7 @@ extern _Nonnull SEL WXSwizzledSelectorForSelector(_Nonnull SEL selector);
  * @return A font object according to the above params.
  *
  */
-+ (UIFont *_Nonnull)fontWithSize:(CGFloat)size textWeight:(WXTextWeight)textWeight textStyle:(WXTextStyle)textStyle fontFamily:(NSString *_Nullable)fontFamily;
++ (UIFont *_Nonnull)fontWithSize:(CGFloat)size textWeight:(CGFloat)textWeight textStyle:(WXTextStyle)textStyle fontFamily:(NSString *_Nullable)fontFamily;
 
 /**
  * @abstract download remote font from specified url

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -340,7 +340,7 @@ static BOOL WXNotStat;
     return [NSError errorWithDomain:@"WeexErrorDomain" code:code userInfo:@{@"errMsg":message}];
 }
 
-+ (UIFont *)fontWithSize:(CGFloat)size textWeight:(WXTextWeight)textWeight textStyle:(WXTextStyle)textStyle fontFamily:(NSString *)fontFamily
++ (UIFont *)fontWithSize:(CGFloat)size textWeight:(CGFloat)textWeight textStyle:(WXTextStyle)textStyle fontFamily:(NSString *)fontFamily
 {
     CGFloat fontSize = (isnan(size) || size == 0) ?  WX_TEXT_FONT_SIZE : size;
     UIFont *font = nil;
@@ -363,23 +363,22 @@ static BOOL WXNotStat;
             [[WXRuleManager sharedInstance] removeRule:@"fontFace" rule:@{@"fontFamily": fontFamily}];
         }
     }
-    CGFloat weight = WXFontWeightRegular;
-    weight = [WXUtility textWeight:textWeight];
     if (!font) {
         if (fontFamily) {
             font = [UIFont fontWithName:fontFamily size:fontSize];
             if (!font) {
                 WXLogWarning(@"Unknown fontFamily:%@", fontFamily);
-                font = [UIFont systemFontOfSize:fontSize weight:weight];
+                font = [UIFont systemFontOfSize:fontSize weight:textWeight];
             }
         } else {
-            font = [UIFont systemFontOfSize:fontSize weight:weight];
+            font = [UIFont systemFontOfSize:fontSize weight:textWeight];
         }
     }
     UIFontDescriptor *fontD = font.fontDescriptor;
     UIFontDescriptorSymbolicTraits traits = 0;
+    
     traits = (textStyle == WXTextStyleItalic) ? (traits | UIFontDescriptorTraitItalic) : traits;
-    traits = (textWeight == WXFontWeightBold) ? (traits | UIFontDescriptorTraitBold) : traits;
+    traits = (fabs(textWeight-(WX_SYS_VERSION_LESS_THAN(@"8.2")?0.4:UIFontWeightBold)) <= 1e-6) ? (traits | UIFontDescriptorTraitBold) : traits;
     if (traits != 0) {
         fontD = [fontD fontDescriptorWithSymbolicTraits:traits];
         UIFont *tempFont = [UIFont fontWithDescriptor:fontD size:0];
@@ -389,43 +388,6 @@ static BOOL WXNotStat;
     }
     
     return font;
-}
-
-+ (CGFloat )textWeight:(WXTextWeight)type
-{
-    CGFloat weight = WXFontWeightRegular;
-    switch (type) {
-        case WXFontWeightUltraLight:
-            weight = -0.8;
-            break;
-        case WXFontWeightThin:
-            weight = -0.6;
-            break;
-        case WXFontWeightLight:
-            weight = -0.4;
-            break;
-        case WXFontWeightRegular:
-            weight = 0;
-            break;
-        case WXFontWeightMedium:
-            weight = 0.23;
-            break;
-        case WXFontWeightSemibold:
-            weight = 0.3;
-            break;
-        case WXFontWeightBold:
-            weight = 0.4;
-            break;
-        case WXFontWeightHeavy:
-            weight = 0.56;
-            break;
-        case WXFontWeightBlack:
-            weight = 0.62;
-            break;
-        default:
-            break;
-    }
-    return weight;
 }
 
 + (void)getIconfont:(NSURL *)url completion:(void(^)(NSURL *url, NSError *error))completionBlock

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -363,22 +363,23 @@ static BOOL WXNotStat;
             [[WXRuleManager sharedInstance] removeRule:@"fontFace" rule:@{@"fontFamily": fontFamily}];
         }
     }
+    CGFloat weight = WXFontWeightRegular;
+    weight = [WXUtility textWeight:textWeight];
     if (!font) {
         if (fontFamily) {
             font = [UIFont fontWithName:fontFamily size:fontSize];
             if (!font) {
                 WXLogWarning(@"Unknown fontFamily:%@", fontFamily);
-                font = [UIFont systemFontOfSize:fontSize];
+                font = [UIFont systemFontOfSize:fontSize weight:weight];
             }
         } else {
-            font = [UIFont systemFontOfSize:fontSize];
+            font = [UIFont systemFontOfSize:fontSize weight:weight];
         }
     }
-    
     UIFontDescriptor *fontD = font.fontDescriptor;
     UIFontDescriptorSymbolicTraits traits = 0;
     traits = (textStyle == WXTextStyleItalic) ? (traits | UIFontDescriptorTraitItalic) : traits;
-    traits = (textWeight == WXTextWeightBold) ? (traits | UIFontDescriptorTraitBold) : traits;
+    traits = (textWeight == WXFontWeightBold) ? (traits | UIFontDescriptorTraitBold) : traits;
     if (traits != 0) {
         fontD = [fontD fontDescriptorWithSymbolicTraits:traits];
         UIFont *tempFont = [UIFont fontWithDescriptor:fontD size:0];
@@ -388,6 +389,43 @@ static BOOL WXNotStat;
     }
     
     return font;
+}
+
++ (CGFloat )textWeight:(WXTextWeight)type
+{
+    CGFloat weight = WXFontWeightRegular;
+    switch (type) {
+        case WXFontWeightUltraLight:
+            weight = -0.8;
+            break;
+        case WXFontWeightThin:
+            weight = -0.6;
+            break;
+        case WXFontWeightLight:
+            weight = -0.4;
+            break;
+        case WXFontWeightRegular:
+            weight = 0;
+            break;
+        case WXFontWeightMedium:
+            weight = 0.23;
+            break;
+        case WXFontWeightSemibold:
+            weight = 0.3;
+            break;
+        case WXFontWeightBold:
+            weight = 0.4;
+            break;
+        case WXFontWeightHeavy:
+            weight = 0.56;
+            break;
+        case WXFontWeightBlack:
+            weight = 0.62;
+            break;
+        default:
+            break;
+    }
+    return weight;
 }
 
 + (void)getIconfont:(NSURL *)url completion:(void(^)(NSURL *url, NSError *error))completionBlock


### PR DESCRIPTION
### 问题(issue)：
[#3167](http://velocity.alibaba-inc.com/issues/3167)DSL设置了字重，weex sdk需要提供相关字重显示(weex sdk support font weight when DSL set font weight)
### 期望(prospection):
用户在we文件中设置font-weight,三端可以设置相关的字重(set in dsl, native should show text change with font weight)
### 解决方案(Solution)：
jsfm传回字重（normal,bold,100-900）(jsfm send font weight normal,bold,100-900)<br/>
ios将字重对应到系统字库的字重上面,全部支持(ios show text as dsl font weight, ios support nine different font weight)<br/>
字重对应表(font weight chart)

jsfm | ios |value
----|------|------|
100|UIFontWeightUltraLight|-0.8
200|UIFontWeightThin|-0.6
300|UIFontWeightLight|-0.4
400|UIFontWeightRegular|0
500|UIFontWeightMedium|0.23
600|UIFontWeightSemibold|0.3
700|UIFontWeightBold|0.4
800|UIFontWeightHeavy|0.56
900|UIFontWeightBlack|0.62
normal|UIFontWeightRegular|0
bold|UIFontWeightBold|0.4

### 已测试手机系统(test finish ios system)
| ios system|
----|
8.1|
8.4|
10.2|

ios demo<br>

- [参考(reference)](https://developer.mozilla.org/cn/docs/Web/CSS/font-weight)

- demo

```javascript
<template>
  <div>
    <text style="font-size:100px; font-weight: normal">Hello World.</text>
    <text style="font-size:100px; font-weight: 100">Hello World.</text>
    <text style="font-size:100px; font-weight: 200">Hello World.</text>
    <text style="font-size:100px; font-weight: 300">Hello World.</text>
    <text style="font-size:100px; font-weight: 400">Hello World.</text>
    <text style="font-size:100px; font-weight: 500">Hello World.</text>
    <text style="font-size:100px; font-weight: 600">Hello World.</text>
    <text style="font-size:100px; font-weight: 700">Hello World.</text>
    <text style="font-size:100px; font-weight: 800">Hello World.</text>
    <text style="font-size:100px; font-weight: 900">Hello World.</text>
  </div>
</template>
```