### PR TITLE
[jsfm] Support to set viewport (achieve #421)

### DIFF
--- a/html5/frameworks/legacy/app/bundle/bootstrap.js
+++ b/html5/frameworks/legacy/app/bundle/bootstrap.js
@@ -1,6 +1,7 @@
 import semver from 'semver'
 import Vm from '../../vm/index'
 import * as downgrade from '../downgrade'
+import { setViewport } from '../viewport'
 import {
   requireCustomComponent
 } from '../register'
@@ -59,6 +60,11 @@ export function bootstrap (app, name, config, data) {
       ]
     }])
     return new Error(`Downgrade[${downgradeResult.code}]: ${downgradeResult.errorMessage}`)
+  }
+
+  // set viewport
+  if (config.viewport) {
+    setViewport(app, config.viewport)
   }
 
   // 3. create a new Vm with custom component name and data

--- a/html5/frameworks/legacy/app/viewport.js
+++ b/html5/frameworks/legacy/app/viewport.js
@@ -1,0 +1,38 @@
+export function setViewport (app, configs = {}) {
+  /* istanbul ignore if */
+  if (process.env.NODE_ENV === 'development') {
+    console.debug(`[JS Framework] Set viewport (width: ${configs.width}) for app#${app.id}.`)
+    validateViewport(configs)
+  }
+
+  // Send viewport configs to native
+  if (app && app.callTasks) {
+    return app.callTasks([{
+      module: 'meta',
+      method: 'setViewport',
+      args: [configs]
+    }])
+  }
+
+  /* istanbul ignore next */
+  else if (process.env.NODE_ENV === 'development') {
+    console.warn(`[JS Framework] Can't find "callTasks" method on current app.`)
+  }
+}
+
+/**
+ * Validate the viewport config.
+ * @param {Object} configs
+ */
+export function validateViewport (configs = {}) {
+  const { width } = configs
+  if (width) {
+    if (typeof width !== 'number' && width !== 'device-width') {
+      console.warn(`[JS Framework] Not support to use ${width} as viewport width.`)
+      return false
+    }
+    return true
+  }
+  console.warn('[JS Framework] the viewport config should contain the "width" property.')
+  return false
+}

--- a/html5/test/unit/default/app/bundle.js
+++ b/html5/test/unit/default/app/bundle.js
@@ -256,6 +256,21 @@ describe('parsing a bundle file', () => {
         )
         expect(result).instanceof(Error)
       })
+
+      it('with viewport config', () => {
+        bundle.bootstrap(
+          app,
+          '@weex-component/undefined',
+          {
+            viewport: { width: 640 }
+          }
+        )
+        expect(callTasksSpy.callCount).to.be.equal(1)
+        const tasks = callTasksSpy.lastCall.args[0]
+        expect(tasks[0].module).to.be.equal('meta')
+        expect(tasks[0].method).to.be.equal('setViewport')
+        expect(tasks[0].args).to.deep.equal([{ width: 640 }])
+      })
     })
   })
 

--- a/html5/test/unit/default/app/viewport.js
+++ b/html5/test/unit/default/app/viewport.js
@@ -1,0 +1,61 @@
+import chai from 'chai'
+import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+const { expect } = chai
+chai.use(sinonChai)
+
+import * as viewport from '../../../../frameworks/legacy/app/viewport'
+
+describe('viewport', function () {
+  const originalCallNative = global.callNative
+  const { setViewport, validateViewport } = viewport
+  const mockApp = {
+    id: 'mock',
+    callTasks (...args) {
+      global.callNative(...args)
+    }
+  }
+
+  before(() => {
+    sinon.stub(console, 'warn')
+  })
+
+  beforeEach(() => {
+    global.callNative = sinon.spy()
+  })
+  afterEach(() => {
+    global.callNative = originalCallNative
+    console.warn.reset()
+  })
+
+  it('invalid setViewport', () => {
+    setViewport()
+    expect(global.callNative.callCount).to.be.equal(0)
+    setViewport({})
+    expect(global.callNative.callCount).to.be.equal(0)
+  })
+
+  it('setViewport', () => {
+    setViewport(mockApp, {})
+    expect(global.callNative.callCount).to.be.equal(1)
+    setViewport(mockApp, { width: 640 })
+    expect(global.callNative.callCount).to.be.equal(2)
+    setViewport(mockApp, { width: 'device-width' })
+    expect(global.callNative.callCount).to.be.equal(3)
+  })
+
+  it('validateViewport', () => {
+    expect(validateViewport()).to.be.false
+    expect(console.warn.callCount).to.be.equal(1)
+    expect(validateViewport({})).to.be.false
+    expect(console.warn.callCount).to.be.equal(2)
+
+    expect(validateViewport({ width: 200 })).to.be.true
+    expect(console.warn.callCount).to.be.equal(2)
+    expect(validateViewport({ width: 'device-width' })).to.be.true
+    expect(console.warn.callCount).to.be.equal(2)
+
+    expect(validateViewport({ width: 'initial-width' })).to.be.false
+    expect(console.warn.callCount).to.be.equal(3)
+  })
+})


### PR DESCRIPTION
 > Achieve the proposal in #421 .

## DSL

Ref: W3C Spec [CSS Device Adaptation](https://drafts.csswg.org/css-device-adapt/#viewport-meta)

Adding item in config script:

```html
<script type="config">
  {
    "viewport": {
        "width": "device-width",
        ...
    },
    ...
  }
</script>
```

 > **Maybe we will use `<meta>` tag as DSL in future.**

### Supported properties

- `width`: number or `"device-width"` or `"device-height"`
- `height`: number or `"device-width"` or `"device-height"`

## JS-Native API
- module: `meta`
- method: `setViewport`
- args: `[viewportObject]` (just same as viewport object in config script)

