### PR TITLE
* [ios] fix : if _fontFamily is nil set _fontFamily value with the co…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextComponent.m
@@ -324,6 +324,19 @@ do {\
     }
     
     // set font
+    if (!_fontFamily) {
+        NSString *regex = @".*[\\u4e00-\\u9faf].*";//Has Simplified Chinese char
+        NSPredicate *pred = [NSPredicate predicateWithFormat:@"SELF MATCHES %@",regex];
+        if ([pred evaluateWithObject:string]) {
+            if ([[UIDevice currentDevice].systemVersion floatValue] < 9.0) {
+                //“Heiti SC” font is "[UIFont systemFontOfSize:]" for Simplified Chinese before iOS 9.0.
+                _fontFamily = @"Heiti SC";
+            } else {
+                //“PingFang SC” font is "[UIFont systemFontOfSize:]" for Simplified Chinese from iOS 9.0.
+                _fontFamily = @"PingFang SC";
+            }
+        }
+    }
     UIFont *font = [WXUtility fontWithSize:_fontSize textWeight:_fontWeight textStyle:_fontStyle fontFamily:_fontFamily scaleFactor:self.weexInstance.pixelScaleFactor];
     if (font) {
         [attributedString addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, string.length)];


### PR DESCRIPTION
…rrect system font. In the case of Chinese characters, this logic help system select the right system default font name.

<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->
解决中英文混合文本时不设置字体时中英文显示对不齐问题。解决方案是：在有中文情况下如果不设置字体则设置为系统默认中文字体。