### PR TITLE
+ [ios] feature: follow w3c standard.  weex provide  websocket  module

### DIFF
--- a/ios/playground/WeexDemo.xcodeproj/project.pbxproj
+++ b/ios/playground/WeexDemo.xcodeproj/project.pbxproj
@@ -307,10 +307,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 775BEEA81C1E8ECC008D1629 /* Build configuration list for PBXNativeTarget "WeexDemo" */;
 			buildPhases = (
+				B5825066F03BDD65A25F2701 /* 📦 Check Pods Manifest.lock */,
 				74CC7A221C2C13BF00829368 /* Start Samples */,
 				775BEE771C1E8ECC008D1629 /* Sources */,
 				775BEE781C1E8ECC008D1629 /* Frameworks */,
 				775BEE791C1E8ECC008D1629 /* Resources */,
+				685399B3421CD1410375A2AD /* 📦 Embed Pods Frameworks */,
+				C715566148067A7FFAB7797D /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -445,6 +448,21 @@
 			shellPath = /bin/sh;
 			shellScript = "myFile=\"XcodeCoverage/exportenv.sh\"\n\nif [ -f \"$myFile\" ]; then\nXcodeCoverage/exportenv.sh\nfi";
 		};
+		685399B3421CD1410375A2AD /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WeexDemo/Pods-WeexDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		74CC7A221C2C13BF00829368 /* Start Samples */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -502,6 +520,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WeexUITestDemo/Pods-WeexUITestDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B5825066F03BDD65A25F2701 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		C715566148067A7FFAB7797D /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WeexDemo/Pods-WeexDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/sdk/WeexSDK.xcodeproj/project.pbxproj
+++ b/ios/sdk/WeexSDK.xcodeproj/project.pbxproj
@@ -220,6 +220,17 @@
 		C41E1A981DC1FD15009C7F90 /* WXDatePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C41E1A961DC1FD15009C7F90 /* WXDatePickerManager.m */; };
 		C4B834271DE69B09007AD27E /* WXPickerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C4B834251DE69B09007AD27E /* WXPickerModule.m */; };
 		C4B834281DE69B09007AD27E /* WXPickerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = C4B834261DE69B09007AD27E /* WXPickerModule.h */; };
+		C4F012791E1502A6003378D0 /* SRWebSocket+Weex.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F012721E1502A6003378D0 /* SRWebSocket+Weex.h */; };
+		C4F0127A1E1502A6003378D0 /* SRWebSocket+Weex.m in Sources */ = {isa = PBXBuildFile; fileRef = C4F012731E1502A6003378D0 /* SRWebSocket+Weex.m */; };
+		C4F0127B1E1502A6003378D0 /* WXWebSocketDefaultImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F012741E1502A6003378D0 /* WXWebSocketDefaultImpl.h */; };
+		C4F0127C1E1502A6003378D0 /* WXWebSocketDefaultImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = C4F012751E1502A6003378D0 /* WXWebSocketDefaultImpl.m */; };
+		C4F0127D1E1502A6003378D0 /* WXWebSocketHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F012761E1502A6003378D0 /* WXWebSocketHandler.h */; };
+		C4F0127E1E1502A6003378D0 /* WXWebSocketModel.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F012771E1502A6003378D0 /* WXWebSocketModel.h */; };
+		C4F0127F1E1502A6003378D0 /* WXWebSocketModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C4F012781E1502A6003378D0 /* WXWebSocketModel.m */; };
+		C4F012821E1502E9003378D0 /* WXWebSocketModule.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F012801E1502E9003378D0 /* WXWebSocketModule.h */; };
+		C4F012831E1502E9003378D0 /* WXWebSocketModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C4F012811E1502E9003378D0 /* WXWebSocketModule.m */; };
+		C4F012861E150307003378D0 /* WXWebSocketLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F012841E150307003378D0 /* WXWebSocketLoader.h */; };
+		C4F012871E150307003378D0 /* WXWebSocketLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = C4F012851E150307003378D0 /* WXWebSocketLoader.m */; };
 		D312CE3B1C730DEB00046D68 /* WXWebComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = D312CE391C730DEB00046D68 /* WXWebComponent.h */; };
 		D312CE3C1C730DEB00046D68 /* WXWebComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = D312CE3A1C730DEB00046D68 /* WXWebComponent.m */; };
 		D317338C1C57257000BB7539 /* WXTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = D317338A1C57257000BB7539 /* WXTransform.h */; };
@@ -494,6 +505,17 @@
 		C41E1A961DC1FD15009C7F90 /* WXDatePickerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXDatePickerManager.m; sourceTree = "<group>"; };
 		C4B834251DE69B09007AD27E /* WXPickerModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXPickerModule.m; sourceTree = "<group>"; };
 		C4B834261DE69B09007AD27E /* WXPickerModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXPickerModule.h; sourceTree = "<group>"; };
+		C4F012721E1502A6003378D0 /* SRWebSocket+Weex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SRWebSocket+Weex.h"; sourceTree = "<group>"; };
+		C4F012731E1502A6003378D0 /* SRWebSocket+Weex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SRWebSocket+Weex.m"; sourceTree = "<group>"; };
+		C4F012741E1502A6003378D0 /* WXWebSocketDefaultImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXWebSocketDefaultImpl.h; sourceTree = "<group>"; };
+		C4F012751E1502A6003378D0 /* WXWebSocketDefaultImpl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXWebSocketDefaultImpl.m; sourceTree = "<group>"; };
+		C4F012761E1502A6003378D0 /* WXWebSocketHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXWebSocketHandler.h; sourceTree = "<group>"; };
+		C4F012771E1502A6003378D0 /* WXWebSocketModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXWebSocketModel.h; sourceTree = "<group>"; };
+		C4F012781E1502A6003378D0 /* WXWebSocketModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXWebSocketModel.m; sourceTree = "<group>"; };
+		C4F012801E1502E9003378D0 /* WXWebSocketModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXWebSocketModule.h; sourceTree = "<group>"; };
+		C4F012811E1502E9003378D0 /* WXWebSocketModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXWebSocketModule.m; sourceTree = "<group>"; };
+		C4F012841E150307003378D0 /* WXWebSocketLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WXWebSocketLoader.h; path = Loader/WXWebSocketLoader.h; sourceTree = "<group>"; };
+		C4F012851E150307003378D0 /* WXWebSocketLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WXWebSocketLoader.m; path = Loader/WXWebSocketLoader.m; sourceTree = "<group>"; };
 		D312CE391C730DEB00046D68 /* WXWebComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXWebComponent.h; sourceTree = "<group>"; };
 		D312CE3A1C730DEB00046D68 /* WXWebComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXWebComponent.m; sourceTree = "<group>"; };
 		D317338A1C57257000BB7539 /* WXTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXTransform.h; sourceTree = "<group>"; };
@@ -621,6 +643,8 @@
 		742AD7371DF98C72007DC46C /* Loader */ = {
 			isa = PBXGroup;
 			children = (
+				C4F012841E150307003378D0 /* WXWebSocketLoader.h */,
+				C4F012851E150307003378D0 /* WXWebSocketLoader.m */,
 				742AD7381DF98C8B007DC46C /* WXResourceLoader.h */,
 				742AD7391DF98C8B007DC46C /* WXResourceLoader.m */,
 			);
@@ -782,6 +806,7 @@
 		77D161181C02DCB90010B15B /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C4F012711E1502A6003378D0 /* WebSocket */,
 				DC0F99301D48E5320087C6AF /* WeexSDK.h */,
 				2AF626C61C191E2200E71A38 /* Layout */,
 				742AD7371DF98C72007DC46C /* Loader */,
@@ -934,6 +959,8 @@
 		77E659D71C07F585008B8775 /* Module */ = {
 			isa = PBXGroup;
 			children = (
+				C4F012801E1502E9003378D0 /* WXWebSocketModule.h */,
+				C4F012811E1502E9003378D0 /* WXWebSocketModule.m */,
 				C4B834251DE69B09007AD27E /* WXPickerModule.m */,
 				C4B834261DE69B09007AD27E /* WXPickerModule.h */,
 				DCA0EF621D6EED6F00CB18B9 /* WXGlobalEventModule.h */,
@@ -1039,6 +1066,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		C4F012711E1502A6003378D0 /* WebSocket */ = {
+			isa = PBXGroup;
+			children = (
+				C4F012721E1502A6003378D0 /* SRWebSocket+Weex.h */,
+				C4F012731E1502A6003378D0 /* SRWebSocket+Weex.m */,
+				C4F012741E1502A6003378D0 /* WXWebSocketDefaultImpl.h */,
+				C4F012751E1502A6003378D0 /* WXWebSocketDefaultImpl.m */,
+				C4F012761E1502A6003378D0 /* WXWebSocketHandler.h */,
+				C4F012771E1502A6003378D0 /* WXWebSocketModel.h */,
+				C4F012781E1502A6003378D0 /* WXWebSocketModel.m */,
+			);
+			path = WebSocket;
+			sourceTree = "<group>";
+		};
 		DC9F46841D61AC9100A88239 /* module */ = {
 			isa = PBXGroup;
 			children = (
@@ -1091,6 +1132,7 @@
 				2AE5B7561CABA04E0082FDDB /* WXEventModuleProtocol.h in Headers */,
 				591DD3321D23AD5800BE8709 /* WXErrorView.h in Headers */,
 				D362F94F1C83EDA20003F546 /* WXWebViewModule.h in Headers */,
+				C4F012861E150307003378D0 /* WXWebSocketLoader.h in Headers */,
 				77D161381C02DE940010B15B /* WXBridgeManager.h in Headers */,
 				77D161281C02DE1A0010B15B /* WXSDKManager.h in Headers */,
 				59CE27E81CC387DB000BE37A /* WXEmbedComponent.h in Headers */,
@@ -1107,6 +1149,7 @@
 				74EF31AD1DE58BE200667A07 /* WXURLRewriteDefaultImpl.h in Headers */,
 				74862F791E02B88D00B7A041 /* JSValue+Weex.h in Headers */,
 				2A1F57B71C75C6A600B58017 /* WXTextInputComponent.h in Headers */,
+				C4F012791E1502A6003378D0 /* SRWebSocket+Weex.h in Headers */,
 				74A4BA9A1CB3BAA100195969 /* WXThreadSafeMutableDictionary.h in Headers */,
 				74A4BA9E1CB3C0A100195969 /* WXHandlerFactory.h in Headers */,
 				741DFE021DDD7D18009B020F /* WXRoundedRect.h in Headers */,
@@ -1122,6 +1165,7 @@
 				741081261CEDB4EC001BC6E5 /* WXComponent_internal.h in Headers */,
 				77E65A191C155F25008B8775 /* WXScrollerComponent.h in Headers */,
 				742AD7311DF98C45007DC46C /* WXResourceRequestHandlerDefaultImpl.h in Headers */,
+				C4F0127D1E1502A6003378D0 /* WXWebSocketHandler.h in Headers */,
 				DC03ADBA1D508719003F76E7 /* WXTextAreaComponent.h in Headers */,
 				2AC750241C7565690041D390 /* WXIndicatorComponent.h in Headers */,
 				DCAB35FE1D658EB700C0EA70 /* WXRuleManager.h in Headers */,
@@ -1130,6 +1174,7 @@
 				742AD7331DF98C45007DC46C /* WXResourceResponse.h in Headers */,
 				77E65A0D1C155E99008B8775 /* WXDivComponent.h in Headers */,
 				C41E1A971DC1FD15009C7F90 /* WXDatePickerManager.h in Headers */,
+				C4F0127B1E1502A6003378D0 /* WXWebSocketDefaultImpl.h in Headers */,
 				7461F8901CFB373100F62D44 /* WXDisplayQueue.h in Headers */,
 				DCC77C141D770AE300CE7288 /* WXSliderNeighborComponent.h in Headers */,
 				77E659F11C0C3612008B8775 /* WXModuleFactory.h in Headers */,
@@ -1145,10 +1190,12 @@
 				77E65A151C155EB5008B8775 /* WXTextComponent.h in Headers */,
 				74CC7A1C1C2BC5F800829368 /* WXCellComponent.h in Headers */,
 				74896F301D1AC79400D1D593 /* NSObject+WXSwizzle.h in Headers */,
+				C4F012821E1502E9003378D0 /* WXWebSocketModule.h in Headers */,
 				74EF31AA1DE58AE600667A07 /* WXURLRewriteProtocol.h in Headers */,
 				59A596241CB6311F0012CD52 /* WXStorageModule.h in Headers */,
 				74A4BA851CAD453400195969 /* WXNetworkProtocol.h in Headers */,
 				7461F8A81CFC33A800F62D44 /* WXThreadSafeMutableArray.h in Headers */,
+				C4F0127E1E1502A6003378D0 /* WXWebSocketModel.h in Headers */,
 				D33451081D3E19480083598A /* WXCanvasComponent.h in Headers */,
 				74B8BEFE1DC47B72004A6027 /* WXRootView.h in Headers */,
 				77E65A111C155EA8008B8775 /* WXImageComponent.h in Headers */,
@@ -1366,6 +1413,7 @@
 				746986A01C4E2C010054A57E /* NSArray+Weex.m in Sources */,
 				74B8BEFF1DC47B72004A6027 /* WXRootView.m in Sources */,
 				742AD7321DF98C45007DC46C /* WXResourceRequestHandlerDefaultImpl.m in Sources */,
+				C4F0127C1E1502A6003378D0 /* WXWebSocketDefaultImpl.m in Sources */,
 				77E65A0E1C155E99008B8775 /* WXDivComponent.m in Sources */,
 				2A60CE9D1C91733E00857B9F /* WXSwitchComponent.m in Sources */,
 				2A837AB71CD9DE9200AEDF03 /* WXRefreshComponent.m in Sources */,
@@ -1373,6 +1421,7 @@
 				77E65A1A1C155F25008B8775 /* WXScrollerComponent.m in Sources */,
 				747A787D1D1BAAC900DED9D0 /* WXComponent+ViewManagement.m in Sources */,
 				2A837AB51CD9DE9200AEDF03 /* WXLoadingIndicator.m in Sources */,
+				C4F012831E1502E9003378D0 /* WXWebSocketModule.m in Sources */,
 				59D3CA401CF9ED57008835DC /* Layout.c in Sources */,
 				DCF087621DCAE161005CD6EB /* WXInvocationConfig.m in Sources */,
 				77D161311C02DE4E0010B15B /* WXComponent.m in Sources */,
@@ -1415,6 +1464,7 @@
 				74915F481C8EB02B00BEBCC0 /* WXAssert.m in Sources */,
 				59A596251CB6311F0012CD52 /* WXStorageModule.m in Sources */,
 				2AFEB17C1C747139000507FA /* WXInstanceWrap.m in Sources */,
+				C4F0127F1E1502A6003378D0 /* WXWebSocketModel.m in Sources */,
 				74A4BA5C1CABBBD000195969 /* WXDebugTool.m in Sources */,
 				742AD73B1DF98C8B007DC46C /* WXResourceLoader.m in Sources */,
 				D334510D1D3E19B80083598A /* WXCanvasModule.m in Sources */,
@@ -1432,6 +1482,7 @@
 				7423899C1C3174EB00D748CA /* WXWeakObjectWrapper.m in Sources */,
 				744BEA561D05178F00452B5D /* WXComponent+Display.m in Sources */,
 				7408C48F1CFB345D000BCCD0 /* WXComponent+Events.m in Sources */,
+				C4F012871E150307003378D0 /* WXWebSocketLoader.m in Sources */,
 				745ED2DB1C5F2C7E002DB5A8 /* WXView.m in Sources */,
 				DC03ADB91D508719003F76E7 /* WXTextAreaComponent.m in Sources */,
 				59A596231CB6311F0012CD52 /* WXNavigatorModule.m in Sources */,
@@ -1453,6 +1504,7 @@
 				749DC27C1D40827B009E1C91 /* WXMonitor.m in Sources */,
 				77E659FB1C0EE579008B8775 /* WXBridgeMethod.m in Sources */,
 				C4B834271DE69B09007AD27E /* WXPickerModule.m in Sources */,
+				C4F0127A1E1502A6003378D0 /* SRWebSocket+Weex.m in Sources */,
 				59970D2F1E0D228D0049F535 /* WXComponent+GradientColor.m in Sources */,
 				77D161391C02DE940010B15B /* WXBridgeManager.m in Sources */,
 			);

--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -16,6 +16,7 @@
 #import "WXResourceRequestHandlerDefaultImpl.h"
 #import "WXNavigationDefaultImpl.h"
 #import "WXURLRewriteDefaultImpl.h"
+#import "WXWebSocketDefaultImpl.h"
 
 #import "WXSDKManager.h"
 #import "WXSDKError.h"
@@ -46,6 +47,7 @@
     [self registerModule:@"canvas" withClass:NSClassFromString(@"WXCanvasModule")];
     [self registerModule:@"picker" withClass:NSClassFromString(@"WXPickerModule")];
     [self registerModule:@"meta" withClass:NSClassFromString(@"WXMetaModule")];
+    [self registerModule:@"WebSocket" withClass:NSClassFromString(@"WXWebSocketModule")];
 }
 
 + (void)registerModule:(NSString *)name withClass:(Class)clazz
@@ -142,6 +144,8 @@
     [self registerHandler:[WXResourceRequestHandlerDefaultImpl new] withProtocol:@protocol(WXResourceRequestHandler)];
     [self registerHandler:[WXNavigationDefaultImpl new] withProtocol:@protocol(WXNavigationProtocol)];
     [self registerHandler:[WXURLRewriteDefaultImpl new] withProtocol:@protocol(WXURLRewriteProtocol)];
+    [self registerHandler:[WXWebSocketDefaultImpl new] withProtocol:@protocol(WXWebSocketHandler)];
+
 }
 
 + (void)registerHandler:(id)handler withProtocol:(Protocol *)protocol

--- a/ios/sdk/WeexSDK/Sources/Loader/WXWebSocketLoader.h
+++ b/ios/sdk/WeexSDK/Sources/Loader/WXWebSocketLoader.h
@@ -1,0 +1,24 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface WXWebSocketLoader : NSObject
+
+@property (nonatomic, copy) void (^onOpen)();
+@property (nonatomic, copy) void (^onReceiveMessage)(id);
+@property (nonatomic, copy) void (^onClose)(NSInteger,NSString *,BOOL);
+@property (nonatomic, copy) void (^onFail)(NSError *);
+
+- (instancetype)initWithUrl:(NSString *)url protocol:(NSString *)protocol;
+- (void)open;
+- (void)send:(NSString *)data;
+- (void)close;
+- (void)close:(NSString *)code reason:(NSString *)reason;
+- (void)clear;
+@end

--- a/ios/sdk/WeexSDK/Sources/Loader/WXWebSocketLoader.m
+++ b/ios/sdk/WeexSDK/Sources/Loader/WXWebSocketLoader.m
@@ -1,0 +1,119 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "WXWebSocketLoader.h"
+#import "WXWebSocketHandler.h"
+#import "WXWebSocketModel.h"
+#import "WXHandlerFactory.h"
+#import "WXLog.h"
+
+@interface WXWebSocketLoader () <WXWebSocketDelegate>
+@property (nonatomic, strong) WXWebSocketModel *webSocketModel;
+@end
+
+@implementation WXWebSocketLoader
+
+- (instancetype)initWithUrl:(NSString *)url protocol:(NSString *)protocol
+{
+    if (self = [super init]) {
+        self.webSocketModel = [self webSocketModel];
+        self.webSocketModel.url = url;
+        self.webSocketModel.protocol = protocol;
+    }
+    return self;
+}
+
+-(WXWebSocketModel *)webSocketModel
+{
+    if(!_webSocketModel)
+    {
+        _webSocketModel = [WXWebSocketModel new];
+        CFUUIDRef uuid = CFUUIDCreate(NULL);
+        _webSocketModel.identifier = CFBridgingRelease(CFUUIDCreateString(NULL, uuid));
+        assert(_webSocketModel.identifier);
+        CFRelease(uuid);
+    }
+    return _webSocketModel;
+}
+
+- (void)open
+{
+    id<WXWebSocketHandler> requestHandler = [WXHandlerFactory handlerForProtocol:@protocol(WXWebSocketHandler)];
+    if (requestHandler) {
+        [requestHandler open:self.webSocketModel withDelegate:self];
+    } else {
+        WXLogError(@"No resource request handler found!");
+    }
+}
+
+- (void)send:(NSString *)data
+{
+    id<WXWebSocketHandler> requestHandler = [WXHandlerFactory handlerForProtocol:@protocol(WXWebSocketHandler)];
+    if (requestHandler) {
+        [requestHandler send:self.webSocketModel data:data];
+    } else {
+        WXLogError(@"No resource request handler found!");
+    }
+}
+
+- (void)close
+{
+    id<WXWebSocketHandler> requestHandler = [WXHandlerFactory handlerForProtocol:@protocol(WXWebSocketHandler)];
+    if (requestHandler) {
+        [requestHandler close:self.webSocketModel];
+    } else {
+        WXLogError(@"No resource request handler found!");
+    }
+}
+
+- (void)clear
+{
+    id<WXWebSocketHandler> requestHandler = [WXHandlerFactory handlerForProtocol:@protocol(WXWebSocketHandler)];
+    if (requestHandler) {
+        [requestHandler clear:self.webSocketModel];
+    } else {
+        WXLogError(@"No resource request handler found!");
+    }
+}
+
+- (void)close:(NSString *)code reason:(NSString *)reason
+{
+    id<WXWebSocketHandler> requestHandler = [WXHandlerFactory handlerForProtocol:@protocol(WXWebSocketHandler)];
+    if (requestHandler) {
+        [requestHandler close:self.webSocketModel code:code reason:reason];
+    } else {
+        WXLogError(@"No resource request handler found!");
+    }
+}
+
+#pragma mark - WXWebSocketDelegate
+- (void)didOpen
+{
+    if (self.onOpen) {
+        self.onOpen();
+    }
+}
+- (void)didFailWithError:(NSError *)error
+{
+    if(self.onFail) {
+        self.onFail(error);
+    }
+}
+- (void)didReceiveMessage:(id)message
+{
+    if (self.onReceiveMessage) {
+        self.onReceiveMessage(message);
+    }
+}
+- (void)didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean
+{
+    if (self.onClose) {
+        self.onClose(code,reason,wasClean);
+    }
+}
+@end

--- a/ios/sdk/WeexSDK/Sources/Module/WXWebSocketModule.h
+++ b/ios/sdk/WeexSDK/Sources/Module/WXWebSocketModule.h
@@ -1,0 +1,15 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import "WXModuleProtocol.h"
+#import "SRWebSocket.h"
+
+@interface WXWebSocketModule : NSObject <WXModuleProtocol>
+
+@end

--- a/ios/sdk/WeexSDK/Sources/Module/WXWebSocketModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXWebSocketModule.m
@@ -1,0 +1,132 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "WXWebSocketModule.h"
+#import "WXUtility.h"
+#import "WXWebSocketHandler.h"
+#import "WXHandlerFactory.h"
+#import "WXWebSocketLoader.h"
+
+@interface WXWebSocketModule()
+
+@property(nonatomic,copy)WXModuleKeepAliveCallback errorCallBack;
+@property(nonatomic,copy)WXModuleKeepAliveCallback messageCallBack;
+@property(nonatomic,copy)WXModuleKeepAliveCallback openCallBack;
+@property(nonatomic,copy)WXModuleKeepAliveCallback closeCallBack;
+
+@end
+
+@implementation WXWebSocketModule
+{
+    WXWebSocketLoader *loader;
+}
+WX_EXPORT_METHOD(@selector(WebSocket:protocol:))
+WX_EXPORT_METHOD(@selector(send:))
+WX_EXPORT_METHOD(@selector(close:reason:))
+WX_EXPORT_METHOD(@selector(onerror:))
+WX_EXPORT_METHOD(@selector(onmessage:))
+WX_EXPORT_METHOD(@selector(onopen:))
+WX_EXPORT_METHOD(@selector(onclose:))
+
+@synthesize weexInstance;
+
+- (void)WebSocket:(NSString *)url protocol:(NSString *)protocol
+{
+    loader = [[WXWebSocketLoader alloc] initWithUrl:url protocol:protocol];
+    __weak typeof(self) weakSelf = self;
+    loader.onReceiveMessage = ^(id message) {
+        if (weakSelf) {
+            NSMutableDictionary *dic = [NSMutableDictionary new];
+            if([message isKindOfClass:[NSString class]]) {
+                [dic setObject:message forKey:@"data"];
+            }
+            if (weakSelf.messageCallBack) {
+                weakSelf.messageCallBack(dic,true);;
+            }
+        }
+    };
+    loader.onOpen = ^() {
+        if (weakSelf) {
+            if (weakSelf.openCallBack) {
+                NSMutableDictionary *dict = [NSMutableDictionary new];
+                weakSelf.openCallBack(dict,true);;
+            }
+        }
+    };
+    loader.onFail = ^(NSError *error) {
+        if (weakSelf) {
+            WXLogError(@":( Websocket Failed With Error %@", error);
+            NSMutableDictionary *dict = [NSMutableDictionary new];
+            [dict setObject:error.userInfo forKey:@"data"];
+            if (weakSelf.errorCallBack) {
+                weakSelf.errorCallBack(dict, true);
+            }
+        }
+    };
+    loader.onClose = ^(NSInteger code,NSString *reason,BOOL wasClean) {
+        if (weakSelf) {
+            if (weakSelf.closeCallBack) {
+                WXLogInfo(@"Websocket colse ");
+                NSMutableDictionary * callbackRsp = [[NSMutableDictionary alloc] init];
+                [callbackRsp setObject:[NSNumber numberWithInteger:code] forKey:@"code"];
+                [callbackRsp setObject:reason forKey:@"reason"];
+                [callbackRsp setObject:wasClean?@true:@false forKey:@"wasClean"];
+                weakSelf.closeCallBack(callbackRsp,false);
+            }
+        }
+    };
+    
+    [loader open];
+}
+
+- (void)send:(NSString *)data
+{
+    [loader send:data];
+}
+
+- (void)close
+{
+    [loader close];
+}
+
+- (void)close:(NSString *)code reason:(NSString *)reason
+{
+    if(!code)
+    {
+        [loader close];
+        return;
+    }
+    [loader close:code reason:reason];
+}
+
+- (void)onerror:(WXModuleKeepAliveCallback)callback
+{
+    self.errorCallBack = callback;
+}
+
+- (void)onmessage:(WXModuleKeepAliveCallback)callback
+{
+    self.messageCallBack = callback;
+}
+
+- (void)onopen:(WXModuleKeepAliveCallback)callback
+{
+    self.openCallBack = callback;
+}
+
+- (void)onclose:(WXModuleKeepAliveCallback)callback
+{
+    self.closeCallBack = callback;
+}
+
+-(void)dealloc
+{
+    [loader clear];
+}
+
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/SRWebSocket+Weex.h
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/SRWebSocket+Weex.h
@@ -1,0 +1,16 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "SRWebSocket.h"
+#import <objc/runtime.h>
+
+@interface SRWebSocket (Weex)
+
+@property (nonatomic, copy) NSString *identifier;
+
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/SRWebSocket+Weex.m
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/SRWebSocket+Weex.m
@@ -1,0 +1,24 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "SRWebSocket+Weex.h"
+static char identifierKey;
+
+@implementation SRWebSocket (Weex)
+
+-(void)setIdentifier:(NSString *)identifier
+{
+    objc_setAssociatedObject(self, &identifierKey, identifier, OBJC_ASSOCIATION_COPY);
+}
+
+-(NSString *)identifier
+{
+    return objc_getAssociatedObject(self, &identifierKey);
+}
+
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketDefaultImpl.h
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketDefaultImpl.h
@@ -1,0 +1,14 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import "WXWebSocketHandler.h"
+
+@interface WXWebSocketDefaultImpl : NSObject<WXWebSocketHandler>
+
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketDefaultImpl.m
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketDefaultImpl.m
@@ -1,0 +1,106 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "WXWebSocketDefaultImpl.h"
+#import "SRWebSocket.h"
+#import "WXThreadSafeMutableDictionary.h"
+#import "SRWebSocket+Weex.h"
+
+@interface WXWebSocketDefaultImpl()<SRWebSocketDelegate>
+
+@end
+
+@implementation WXWebSocketDefaultImpl
+{
+    WXThreadSafeMutableDictionary<NSString *, id<WXWebSocketDelegate>> *_delegates;
+}
+
+#pragma mark - WXWebSocketHandler
+- (void)open:(WXWebSocketModel *)webSocketModel withDelegate:(id<WXWebSocketDelegate>)delegate
+{
+    if(!_delegates)
+    {
+        _delegates = [WXThreadSafeMutableDictionary new];
+    }
+    if(webSocketModel.identifier){
+        [_delegates removeObjectForKey:webSocketModel.identifier];
+        SRWebSocket *webSocket = webSocketModel.webSocket;
+        webSocket.delegate = nil;
+        [webSocket close];
+        
+    }
+    NSArray *protols;
+    if([webSocketModel.protocol length]>0){
+       protols = [NSArray arrayWithObject:webSocketModel.protocol];
+    }
+    SRWebSocket *webSocket = [[SRWebSocket alloc] initWithURL:[NSURL URLWithString:webSocketModel.url] protocols:protols];
+    webSocket.delegate = self;
+    [webSocket open];
+    webSocketModel.webSocket = webSocket;
+    webSocket.identifier = webSocketModel.identifier;
+    [_delegates setObject:delegate forKey:webSocket.identifier];
+}
+
+- (void)send:(WXWebSocketModel *)webSocketModel data:(NSString *)data
+{
+    [webSocketModel.webSocket send:data];
+}
+
+- (void)close:(WXWebSocketModel *)webSocketModel
+{
+    [webSocketModel.webSocket close];
+}
+
+- (void)close:(WXWebSocketModel *)webSocketModel code:(NSString *)code reason:(NSString *)reason
+{
+    [webSocketModel.webSocket closeWithCode:[code integerValue] reason:reason];
+}
+
+- (void)clear:(WXWebSocketModel *)webSocketModel
+{
+    if ([webSocketModel.identifier isKindOfClass:[NSString class]]) {
+        SRWebSocket *websocket = webSocketModel.webSocket;
+        websocket.delegate = nil;
+        [websocket close];
+        [_delegates removeObjectForKey:webSocketModel.identifier];
+    }
+}
+
+#pragma mark -SRWebSocketDelegate
+- (void)webSocketDidOpen:(SRWebSocket *)webSocket;
+{
+    id<WXWebSocketDelegate> delegate = [_delegates objectForKey:webSocket.identifier];
+    if (delegate && [delegate respondsToSelector:@selector(didOpen)]) {
+        [delegate didOpen];
+    }
+}
+
+- (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;
+{
+    id<WXWebSocketDelegate> delegate = [_delegates objectForKey:webSocket.identifier];
+    if (delegate && [delegate respondsToSelector:@selector(didFailWithError:)]) {
+        [delegate didFailWithError:error];
+    }
+}
+
+- (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message;
+{
+    id<WXWebSocketDelegate> delegate = [_delegates objectForKey:webSocket.identifier];
+    if (delegate && [delegate respondsToSelector:@selector(didReceiveMessage:)]) {
+        [delegate didReceiveMessage:message];
+    }
+}
+
+- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
+{
+    id<WXWebSocketDelegate> delegate = [_delegates objectForKey:webSocket.identifier];
+    if (delegate && [delegate respondsToSelector:@selector(didCloseWithCode:reason:wasClean:)]) {
+        [delegate didCloseWithCode:code reason:reason wasClean:wasClean];
+    }
+}
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketHandler.h
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketHandler.h
@@ -1,0 +1,27 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import "WXModuleProtocol.h"
+#import "WXWebSocketModel.h"
+
+@protocol WXWebSocketDelegate<NSObject>
+- (void)didOpen;
+- (void)didFailWithError:(NSError *)error;
+- (void)didReceiveMessage:(id)message;
+- (void)didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
+@end
+
+@protocol WXWebSocketHandler<NSObject>
+
+- (void)open:(WXWebSocketModel *)webSocketModel withDelegate:(id<WXWebSocketDelegate>)delegate;
+- (void)send:(WXWebSocketModel *)webSocketModel data:(NSString *)data;
+- (void)close:(WXWebSocketModel *)webSocketModel;
+- (void)close:(WXWebSocketModel *)webSocketModel code:(NSString *)code reason:(NSString *)reason;
+- (void)clear:(WXWebSocketModel *)webSocketModel;
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketModel.h
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketModel.h
@@ -1,0 +1,18 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface WXWebSocketModel : NSObject
+
+@property (nonatomic, copy) NSString  *url;
+@property (nonatomic, copy) NSString  *protocol;
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, strong) id webSocket;
+
+@end

--- a/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketModel.m
+++ b/ios/sdk/WeexSDK/Sources/WebSocket/WXWebSocketModel.m
@@ -1,0 +1,13 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "WXWebSocketModel.h"
+
+@implementation WXWebSocketModel
+
+@end


### PR DESCRIPTION
#### websocket [参考](https://developer.mozilla.org/zh-CN/docs/Web/API/WebSocket)
* 名字
  - websocket
* 描述
  - websocket在聊天应用，小游戏中会用到，建议加上基础功能websokcet，实现后，可以用于应用的交互场景，websocket已经是大多数程序的必备功能
* 平台
  - ios,android,H5
* 类型
  - module
* 解决方案
  - weex 提供websocket，h5 直接用原生的websocket，安卓和ios根据w3c的websocket接口实现对应的接口，需要更改jsfm，jsfm重写方法设置功能， 支持方法的赋值功能，这样jsfm赋值的函数可以监听module的api，从而实现严格按照w3c标准的api
  - weex提供默认的protocol实现，用户也可以实现自己的protocol，增强websocket功能
  - 对于websocket的实例，可以参考stream的实现，根据协议的名字设置（隐风建议一个instance 一个实例）
* api
  - WebSocket(
     string url,
     string option protocol
 );
     - url：需要连接的URL(string)
     - protocol: 协议(string)
  - send(string data)
     - data：发送到服务器的数据(string)
 - close(int code,string reason)
     - code：表示关闭连接的状态号，默认值1000(表示正常连接关闭)(int)
     - reason:可选，表示关闭的原因(string)
 - onerror(e)
     - 当错误发生时用于监听error事件的事件监听器。会接受一个名为error的event对象(dictionary)
         - data(string)：错误数据
 - onmessage(e)
     - 一个用于消息事件的事件监听器，这一事件当有消息到达的时候该事件会触发。这个Listener会被传入一个名为"message"的MessageEvent对象(dictionary)。
         - data(string)：Returns a DOMString, Blob or an ArrayBuffer containing the data send by the emitter,目前支持字符串
 - onopen(e)
     - 一个用于连接打开事件的事件监听器。当readyState的值变为OPEN的时候会触发该事件。该事件表明这个连接已经准备好接受和发送数据。这个监听器会接受一个名为"open"的事件对象。(dictionary)
         - type(string):默认值"open"
 - onclose(e)
     - (dictionary)用于监听连接关闭事件监听器。当WebSocket对象的readyState状态变为CLOSED时会触发该事件。这个监听器会接收一个叫close的对象。
         - code(number):返回一个 unsigned short 类型的数字, 表示服务端发送的关闭码
         - reason(string):用以表示服务器关闭连接的原因. 这是由服务器和子协议决定的
         - wasClean:(bool):用以表示连接是否完全关闭
 -  备注
     - 增加监听：可以墨循想到实现方案，早弦在jsfm 实现了相关功能，方法的代理

     - 使用例子

     ```javascript
     connect:function(e) {
                websocket.WebSocket('ws://115.29.193.48:8088','');
                var self = this;
                websocket.onopen = function(e)
                {
                    self.onopeninfo = e;
                }
                websocket.onmessage = function(e)
                {
                    self.onmessage = e.data;
                }
                websocket.onerror = function(e)
                {
                    self.onerrorinfo = e.data;
                }
                websocket.onclose = function(e)
                {
                    self.onerrorinfo = e.reason;
                }
            },
            send:function(e) {
                var input = this.$el('input');
                input.blur();
                websocket.send(this.txtInput);
                this.sendinfo = this.txtInput;

            },
     ```
