### PR TITLE
* [ios] iconfont fontStorage should not set before download

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
@@ -83,7 +83,8 @@ static WXRuleManager *_sharedInstance = nil;
                 // if the fontSrc string is illegal, the fontURL will be nil
                 return;
             }
-            [fontFamily setObject:fontSrc forKey:@"src"];
+            [fontFamily setObject:fontSrc forKey:@"tempSrc"];
+            [_fontStorage setObject:fontFamily forKey:rule[@"fontFamily"]];
             // remote font file
             NSString *fontfile = [NSString stringWithFormat:@"%@/%@",WX_FONT_DOWNLOAD_DIR,[WXUtility md5:[fontURL absoluteString]]];
             if ([WXUtility isFileExist:fontfile]) {
@@ -95,8 +96,9 @@ static WXRuleManager *_sharedInstance = nil;
             [WXUtility getIconfont:fontURL completion:^(NSURL * _Nonnull url, NSError * _Nullable error) {
                 if (!error && url) {
                     // load success
-                    [weakSelf.fontStorage setObject:fontFamily forKey:rule[@"fontFamily"]];
                     NSMutableDictionary * dictForFontFamily = [weakSelf.fontStorage objectForKey:rule[@"fontFamily"]];
+                    NSString *fontSrc = [dictForFontFamily objectForKey:@"tempSrc"];
+                    [dictForFontFamily setObject:fontSrc forKey:@"src"];
                     [dictForFontFamily setObject:url forKey:@"localSrc"];
                 } else {
                     //there was some errors during loading

--- a/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
@@ -83,7 +83,12 @@ static WXRuleManager *_sharedInstance = nil;
                 // if the fontSrc string is illegal, the fontURL will be nil
                 return;
             }
-            [fontFamily setObject:fontSrc forKey:@"tempSrc"];
+            if([fontURL isFileURL]){
+                [fontFamily setObject:fontSrc forKey:@"src"];
+            }else {
+                [fontFamily setObject:fontSrc forKey:@"tempSrc"];
+            }
+            
             [_fontStorage setObject:fontFamily forKey:rule[@"fontFamily"]];
             // remote font file
             NSString *fontfile = [NSString stringWithFormat:@"%@/%@",WX_FONT_DOWNLOAD_DIR,[WXUtility md5:[fontURL absoluteString]]];

--- a/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
@@ -84,7 +84,6 @@ static WXRuleManager *_sharedInstance = nil;
                 return;
             }
             [fontFamily setObject:fontSrc forKey:@"src"];
-            [_fontStorage setObject:fontFamily forKey:rule[@"fontFamily"]];
             // remote font file
             NSString *fontfile = [NSString stringWithFormat:@"%@/%@",WX_FONT_DOWNLOAD_DIR,[WXUtility md5:[fontURL absoluteString]]];
             if ([WXUtility isFileExist:fontfile]) {
@@ -96,6 +95,7 @@ static WXRuleManager *_sharedInstance = nil;
             [WXUtility getIconfont:fontURL completion:^(NSURL * _Nonnull url, NSError * _Nullable error) {
                 if (!error && url) {
                     // load success
+                    [weakSelf.fontStorage setObject:fontFamily forKey:rule[@"fontFamily"]];
                     NSMutableDictionary * dictForFontFamily = [weakSelf.fontStorage objectForKey:rule[@"fontFamily"]];
                     [dictForFontFamily setObject:url forKey:@"localSrc"];
                 } else {


### PR DESCRIPTION
iconfont fontStorage should set when  download success
复现问题方案：
第一次打开app，iconfont 现在不成功
激活网络，第二次打开iconfont，iconfont会一直不会显示

场景：ios 10 第一次请求系统网络，还没有获取系统网络权限，以后iconfont会一直加载不成功