### PR TITLE
[jsfm] Revert the modification about strict mode temporarily

### DIFF
--- a/html5/frameworks/legacy/app/ctrl/init.js
+++ b/html5/frameworks/legacy/app/ctrl/init.js
@@ -73,7 +73,7 @@ export function init (app, code, data, services) {
     functionBody = code.toString()
   }
   // wrap IFFE and use strict mode
-  functionBody = `(function(global){\n\n"use strict";\n\n ${functionBody} \n\n})(Object.create(this))`
+  functionBody = `(function(global){\n\n ${functionBody} \n\n})(Object.create(this))`
 
   // run code and get result
   const { WXEnvironment } = global
@@ -109,6 +109,7 @@ export function init (app, code, data, services) {
   const globalObjects = Object.assign({
     define: bundleDefine,
     require: bundleRequire,
+    document: bundleDocument,
     bootstrap: bundleBootstrap,
     register: bundleRegister,
     render: bundleRender,

--- a/html5/render/native/index.js
+++ b/html5/render/native/index.js
@@ -11,7 +11,8 @@ for (const serviceName in services) {
   runtime.service.register(serviceName, services[serviceName])
 }
 
-runtime.freezePrototype()
+// Cancel to freeze the prototype
+// runtime.freezePrototype()
 runtime.setNativeConsole()
 
 // register framework meta info

--- a/html5/test/case/tester.js
+++ b/html5/test/case/tester.js
@@ -99,7 +99,7 @@ describe('test input and output', function () {
   })
 
   describe('invalid usage', function () {
-    describe('strict mode', () => {
+    describe.skip('strict mode', () => {
       const readSource = name => getCode('throws/' + name + '.source.js')
 
       let app

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "subversion": {
     "browser": "0.5.0",
-    "framework": "0.19.4",
+    "framework": "0.19.5",
     "transformer": ">=0.1.5 <0.5"
   },
   "description": "A framework for building Mobile cross-platform UI",


### PR DESCRIPTION
Revert some modifications temporarily :

+ Remove `"use strict"` in `functionBody`. No more strict mode. ( revert #1483 )
+ Cancel to freeze the prototype of build-in objects. ( revert #1529 )
+ Still pass `document` parameter to js bundle. (revert #1637 )