### PR TITLE
* [ios] bug fix: doc declare ok is bool type. so change the ok to bool type

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXStreamModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXStreamModule.m
@@ -39,7 +39,7 @@ WX_EXPORT_METHOD(@selector(fetch:callback:progressCallback:))
     
     if (!options || [WXUtility isBlankString:urlStr]) {
         [callbackRsp setObject:@(-1) forKey:@"status"];
-        [callbackRsp setObject:@false forKey:@"ok"];
+        [callbackRsp setObject:@NO forKey:@"ok"];
         callback(callbackRsp);
         
         return;
@@ -74,7 +74,7 @@ WX_EXPORT_METHOD(@selector(fetch:callback:progressCallback:))
         }
         if (!body) {
             [callbackRsp setObject:@(-1) forKey:@"status"];
-            [callbackRsp setObject:@false forKey:@"ok"];
+            [callbackRsp setObject:@NO forKey:@"ok"];
             callback(callbackRsp);
                 
             return;
@@ -112,7 +112,7 @@ WX_EXPORT_METHOD(@selector(fetch:callback:progressCallback:))
         [callbackRsp removeObjectForKey:@"readyState"];
         [callbackRsp removeObjectForKey:@"length"];
         [callbackRsp removeObjectForKey:@"keepalive"];
-        [callbackRsp setObject:httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299 ? @true : @false forKey:@"ok"];
+        [callbackRsp setObject:httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299 ? @YES : @NO forKey:@"ok"];
     
         NSString *responseData = [self stringfromData:data encode:httpResponse.textEncodingName];
         if ([type isEqualToString:@"json"] || [type isEqualToString:@"jsonp"]) {


### PR DESCRIPTION
doc:https://weex-project.io/references/modules/stream.html
ok(boolean): true if status code is bewteen 200～299.
ok's type in android is boolean. so so change the ok to bool type same as android

user can use it as follow:
```javascript
if(ret.ok === true){
         console.log('get:'+ret);
         me.getResult = JSON.stringify(ret.data);
  }else{
         me.getResult = "request failed";
}
```

refer:http://stackoverflow.com/questions/3970794/objective-c-how-to-put-boolean-values-in-json-dictionary