### PR TITLE
remove the `undefined` after the request url

### DIFF
--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -122,7 +122,7 @@ function _xhr (config, callback, progressCallback) {
     })
   }
 
-  xhr.send(config.body)
+  xhr.send(config.body || null)
 }
 
 const stream = {


### PR DESCRIPTION
Request url would take an `undefined` after it where there's no `body` option in `fetch()`.
