### PR TITLE
* [example] correct cpu support tip error

### DIFF
--- a/android/playground/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/playground/app/src/main/res/values-zh-rCN/strings.xml
@@ -141,6 +141,6 @@
   <string name="sbc_name">Google 图书搜索</string>
   <string name="wifi_changing_network">连接到 Wi-Fi \u2026</string>
 
-  <string name="cpu_not_support_tip">对不起,您当前的设备是X86架构.\n我们只支持ARM架构的设备!</string>
+  <string name="cpu_not_support_tip">对不起,您当前的设备是MIPS架构.\n我们只支持ARM和X86架构的设备!</string>
 
 </resources>

--- a/android/playground/app/src/main/res/values/strings.xml
+++ b/android/playground/app/src/main/res/values/strings.xml
@@ -13,8 +13,8 @@
     <string name="dummy_button">Dummy Button</string>
     <string name="dummy_content">WEEX\nPLAYGROUND</string>
 
-    <string name="cpu_not_support_tip">Sorry, your current device is x86 architecture.\n We only
-        support arm architecture devices!
+    <string name="cpu_not_support_tip">Sorry, your current device is MIPS architecture.\n
+        We only support arm and x86 architecture devices!
     </string>
 
     <string name="index_tip">Network Error!\n1.Make sure you use the command "npm run serve"


### PR DESCRIPTION
Correct the cpu support tip, as weex now support x86, and the cpu not support is MIPS.
