### PR TITLE
* [ios] Refactor transform and transition 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 rvm: 2.0.0
+osx_image: xcode8.2
 before_install:
   - gem install danger danger-xcode_summary xcpretty xcpretty-json-formatter
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "xcpretty"
 gem "xcpretty-json-formatter"
 gem "danger"
 gem "danger-xcode_summary"
-
+gem "cocoapods"
 # gem "danger-prose"
 # gem "danger-clorox"
 # gem "danger-mention"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.4)
+    activesupport (4.2.7.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     claide (1.0.1)
@@ -8,6 +15,38 @@ GEM
       cork
       nap
       open4 (~> 1.3)
+    cocoapods (1.1.1)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.1, < 2.0)
+      cocoapods-core (= 1.1.1)
+      cocoapods-deintegrate (>= 1.0.1, < 2.0)
+      cocoapods-downloader (>= 1.1.2, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.1.1, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      fourflusher (~> 2.0.1)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.5.1)
+      nap (~> 1.0)
+      xcodeproj (>= 1.3.3, < 2.0)
+    cocoapods-core (1.1.1)
+      activesupport (>= 4.0.2, < 5)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.1)
+    cocoapods-downloader (1.1.3)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.1.2)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (1.1.0)
     colored (1.2)
     cork (0.2.0)
       colored (~> 1.2)
@@ -26,14 +65,24 @@ GEM
       danger (> 2.0)
     danger-xcode_summary (0.1.0)
       danger-plugin-api (~> 1.0)
+    escape (0.0.4)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
+    fourflusher (2.0.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.0.3)
     git (1.3.0)
+    i18n (0.7.0)
+    json (1.8.3)
     kramdown (1.13.2)
+    minitest (5.10.1)
+    molinillo (0.5.5)
     multipart-post (2.0.0)
+    nanaimo (0.2.3)
     nap (1.1.0)
+    netrc (0.7.8)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
@@ -44,7 +93,16 @@ GEM
       faraday (~> 0.8, < 1.0)
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
+    xcodeproj (1.4.2)
+      CFPropertyList (~> 2.3.3)
+      activesupport (>= 3)
+      claide (>= 1.0.1, < 2.0)
+      colored (~> 1.2)
+      nanaimo (~> 0.2.3)
     xcpretty (0.2.4)
       rouge (~> 1.8)
     xcpretty-json-formatter (0.1.0)
@@ -54,10 +112,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  cocoapods
   danger
   danger-xcode_summary
   xcpretty
   xcpretty-json-formatter
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/ios/sdk/WeexSDK.xcodeproj/project.pbxproj
+++ b/ios/sdk/WeexSDK.xcodeproj/project.pbxproj
@@ -129,6 +129,8 @@
 		746986A01C4E2C010054A57E /* NSArray+Weex.m in Sources */ = {isa = PBXBuildFile; fileRef = 7469869E1C4E2C000054A57E /* NSArray+Weex.m */; };
 		747A787C1D1BAAC900DED9D0 /* WXComponent+ViewManagement.h in Headers */ = {isa = PBXBuildFile; fileRef = 747A787A1D1BAAC900DED9D0 /* WXComponent+ViewManagement.h */; };
 		747A787D1D1BAAC900DED9D0 /* WXComponent+ViewManagement.m in Sources */ = {isa = PBXBuildFile; fileRef = 747A787B1D1BAAC900DED9D0 /* WXComponent+ViewManagement.m */; };
+		747DF6821E31AEE4005C53A8 /* WXLength.h in Headers */ = {isa = PBXBuildFile; fileRef = 747DF6801E31AEE4005C53A8 /* WXLength.h */; };
+		747DF6831E31AEE4005C53A8 /* WXLength.m in Sources */ = {isa = PBXBuildFile; fileRef = 747DF6811E31AEE4005C53A8 /* WXLength.m */; };
 		74862F791E02B88D00B7A041 /* JSValue+Weex.h in Headers */ = {isa = PBXBuildFile; fileRef = 74862F771E02B88D00B7A041 /* JSValue+Weex.h */; };
 		74862F7A1E02B88D00B7A041 /* JSValue+Weex.m in Sources */ = {isa = PBXBuildFile; fileRef = 74862F781E02B88D00B7A041 /* JSValue+Weex.m */; };
 		74862F7D1E03A0F300B7A041 /* WXModuleMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = 74862F7B1E03A0F300B7A041 /* WXModuleMethod.h */; };
@@ -408,6 +410,8 @@
 		7469869E1C4E2C000054A57E /* NSArray+Weex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Weex.m"; sourceTree = "<group>"; };
 		747A787A1D1BAAC900DED9D0 /* WXComponent+ViewManagement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WXComponent+ViewManagement.h"; sourceTree = "<group>"; };
 		747A787B1D1BAAC900DED9D0 /* WXComponent+ViewManagement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WXComponent+ViewManagement.m"; sourceTree = "<group>"; };
+		747DF6801E31AEE4005C53A8 /* WXLength.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXLength.h; sourceTree = "<group>"; };
+		747DF6811E31AEE4005C53A8 /* WXLength.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WXLength.m; sourceTree = "<group>"; };
 		74862F771E02B88D00B7A041 /* JSValue+Weex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JSValue+Weex.h"; sourceTree = "<group>"; };
 		74862F781E02B88D00B7A041 /* JSValue+Weex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "JSValue+Weex.m"; sourceTree = "<group>"; };
 		74862F7B1E03A0F300B7A041 /* WXModuleMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WXModuleMethod.h; sourceTree = "<group>"; };
@@ -950,6 +954,8 @@
 				7461F8A71CFC33A800F62D44 /* WXThreadSafeMutableArray.m */,
 				74896F2E1D1AC79400D1D593 /* NSObject+WXSwizzle.h */,
 				74896F2F1D1AC79400D1D593 /* NSObject+WXSwizzle.m */,
+				747DF6801E31AEE4005C53A8 /* WXLength.h */,
+				747DF6811E31AEE4005C53A8 /* WXLength.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1171,6 +1177,7 @@
 				C4F0127B1E1502A6003378D0 /* WXWebSocketDefaultImpl.h in Headers */,
 				7461F8901CFB373100F62D44 /* WXDisplayQueue.h in Headers */,
 				DCC77C141D770AE300CE7288 /* WXSliderNeighborComponent.h in Headers */,
+				747DF6821E31AEE4005C53A8 /* WXLength.h in Headers */,
 				77E659F11C0C3612008B8775 /* WXModuleFactory.h in Headers */,
 				77D161431C02DEE40010B15B /* WXBridgeProtocol.h in Headers */,
 				59A582D41CF481110081FD3E /* WXAppMonitorProtocol.h in Headers */,
@@ -1406,6 +1413,7 @@
 				746986A01C4E2C010054A57E /* NSArray+Weex.m in Sources */,
 				74B8BEFF1DC47B72004A6027 /* WXRootView.m in Sources */,
 				742AD7321DF98C45007DC46C /* WXResourceRequestHandlerDefaultImpl.m in Sources */,
+				747DF6831E31AEE4005C53A8 /* WXLength.m in Sources */,
 				C4F0127C1E1502A6003378D0 /* WXWebSocketDefaultImpl.m in Sources */,
 				77E65A0E1C155E99008B8775 /* WXDivComponent.m in Sources */,
 				2A60CE9D1C91733E00857B9F /* WXSwitchComponent.m in Sources */,

--- a/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
@@ -9,6 +9,7 @@
 #import "WXScrollerProtocol.h"
 #import "WXComponent.h"
 #import "WXConvert.h"
+#import "WXTransform.h"
 @class WXTouchGestureRecognizer;
 @class WXThreadSafeCounter;
 
@@ -100,8 +101,7 @@
     BOOL _isNeedJoinLayoutSystem;
     BOOL _lazyCreateView;
     
-    NSString *_transform;
-    NSString *_transformOrigin;
+    WXTransform *_transform;
 }
 
 ///--------------------------------------

--- a/ios/sdk/WeexSDK/Sources/Component/WXTransform.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTransform.h
@@ -9,17 +9,18 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 @class WXSDKInstance;
+@class WXLength;
 
 @interface WXTransform : NSObject
 
-@property CGAffineTransform transform;
+@property (nonatomic, assign, readonly) float rotateAngle;
+@property (nonatomic, strong, readonly) WXLength *translateX;
+@property (nonatomic, strong, readonly) WXLength *translateY;
+@property (nonatomic, assign, readonly) float scaleX;
+@property (nonatomic, assign, readonly) float scaleY;
 
-- (instancetype)initWithInstance:(WXSDKInstance *)instance NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCSSValue:(NSString *)cssValue origin:(NSString *)origin instance:(WXSDKInstance *)instance;
 
-- (CATransform3D)getTransform:(NSString *)cssValue;
-- (CATransform3D)getTransform:(NSString *)cssValue withView:(UIView *)view;
-- (CATransform3D)getTransform:(NSString *)cssValue withView:(UIView *)view withOrigin:(NSString *)origin;
-- (CATransform3D)getTransform:(NSString *)cssValue withView:(UIView *)view withOrigin:(NSString *)origin isTransformRotate:(BOOL)isTransformRotate;
-- (float)getRotateAngle;
+- (void)applyTransformForView:(UIView *)view;
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
@@ -8,57 +8,159 @@
 
 #import "WXTransform.h"
 #import "math.h"
+#import "WXLength.h"
 #import "WXUtility.h"
 #import "WXSDKInstance.h"
 
 @interface WXTransform()
 
-@property (nonatomic, weak) UIView *view;
-@property (nonatomic, assign) float rotateAngle;
-@property (nonatomic, assign) BOOL isTransformRotate;
 @property (nonatomic, weak) WXSDKInstance *weexInstance;
 
 @end
 
 @implementation WXTransform
-
-- (instancetype)init
 {
-    return [self initWithInstance:nil];
+    float _rotateAngle;
+    float _scaleX;
+    float _scaleY;
+    WXLength *_translateX;
+    WXLength *_translateY;
+    WXLength *_originX;
+    WXLength *_originY;
 }
 
-- (instancetype)initWithInstance:(WXSDKInstance *)weexInstance;
+- (instancetype)initWithCSSValue:(NSString *)cssValue origin:(NSString *)origin instance:(WXSDKInstance *)instance
 {
     if (self = [super init]) {
-        _isTransformRotate = YES;
+        _weexInstance = instance;
+        _scaleX = 1.0;
+        _scaleY = 1.0;
         _rotateAngle = 0.0;
-        _weexInstance = weexInstance;
+        
+        [self parseTransform:cssValue];
+        [self parseTransformOrigin:origin];
     }
     
     return self;
 }
 
-- (CATransform3D)getTransform:(NSString *)cssValue
+- (float)rotateAngle
 {
-    //CATransform3D transform3D = _view.layer.transform;
-    //_transform = _view ? CGAffineTransformMake(transform3D.m11, transform3D.m12, transform3D.m21, transform3D.m22, transform3D.m41, transform3D.m42) : CGAffineTransformIdentity;
+    return _rotateAngle;
+}
+
+- (WXLength *)translateX
+{
+    return _translateX;
+}
+
+- (WXLength *)translateY
+{
+    return _translateY;
+}
+
+- (float)scaleX
+{
+    return _scaleX;
+}
+
+- (float)scaleY
+{
+    return _scaleY;
+}
+
+- (CGAffineTransform)nativeTransformWithView:(UIView *)view
+{
+    CGAffineTransform nativeTransform = [self nativeTransformWithoutRotateWithView:view];
     
-    _transform = CGAffineTransformIdentity;
-    if (!cssValue || cssValue.length == 0 || [cssValue isEqualToString:@"none"]) {
-        return CATransform3DMakeAffineTransform(_transform);
+    nativeTransform = CGAffineTransformRotate(nativeTransform, _rotateAngle);
+    
+    return nativeTransform;
+}
+
+- (CGAffineTransform)nativeTransformWithoutRotateWithView:(UIView *)view
+{
+    CGAffineTransform nativeTransform = CGAffineTransformIdentity;
+    
+    if (!view || view.bounds.size.width <= 0 || view.bounds.size.height <= 0) {
+        return nativeTransform;
     }
+    
+    if (_translateX || _translateY) {
+        nativeTransform = CGAffineTransformTranslate(nativeTransform, _translateX ? [_translateX valueForMaximumValue:view.bounds.size.width] : 0,  _translateY ? [_translateY valueForMaximumValue:view.bounds.size.height] : 0);
+    }
+    
+    nativeTransform = CGAffineTransformScale(nativeTransform, _scaleX, _scaleY);
+    
+    return nativeTransform;
+}
+
+-(void)setAnchorPoint:(CGPoint)anchorPoint forView:(UIView *)view
+{
+    CGPoint newPoint = CGPointMake(view.bounds.size.width * anchorPoint.x,
+                                   view.bounds.size.height * anchorPoint.y);
+    CGPoint oldPoint = CGPointMake(view.bounds.size.width * view.layer.anchorPoint.x,
+                                   view.bounds.size.height * view.layer.anchorPoint.y);
+    
+    newPoint = CGPointApplyAffineTransform(newPoint, view.transform);
+    oldPoint = CGPointApplyAffineTransform(oldPoint, view.transform);
+    
+    CGPoint position = view.layer.position;
+    
+    position.x -= oldPoint.x;
+    position.x += newPoint.x;
+    
+    position.y -= oldPoint.y;
+    position.y += newPoint.y;
+    
+    view.layer.position = position;
+    view.layer.anchorPoint = anchorPoint;
+}
+
+
+- (void)applyTransformForView:(UIView *)view
+{
+    if (!view || view.bounds.size.width <= 0 || view.bounds.size.height <= 0) {
+        return;
+    }
+    
+    BOOL applyTransformOrigin = _originX || _originY;
+    if (applyTransformOrigin) {
+        /**
+          * Waiting to fix the issue that transform-origin behaves in rotation
+          * http://ronnqvi.st/translate-rotate-translate/
+          **/
+        CGPoint anchorPoint = CGPointMake(
+                                          _originX ? [_originX valueForMaximumValue:view.bounds.size.width] / view.bounds.size.width : 0.5,
+                                          _originY ? [_originY valueForMaximumValue:view.bounds.size.width] / view.bounds.size.height : 0.5);
+        [self setAnchorPoint:anchorPoint forView:view];
+    }
+    
+    CGAffineTransform nativeTransform = [self nativeTransformWithView:view];
+    
+    if (!CGAffineTransformEqualToTransform(view.transform, nativeTransform)) {
+        view.transform = nativeTransform;
+    }
+}
+
+- (void)parseTransform:(NSString *)cssValue
+{
+    if (!cssValue || cssValue.length == 0 || [cssValue isEqualToString:@"none"]) {
+        return;
+    }
+    
     NSError *error = NULL;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(\\w+)\\((.+?)\\)"
                                                                            options:NSRegularExpressionCaseInsensitive
                                                                              error:&error];
-
+    
     NSArray *matches = [regex matchesInString:cssValue options:0 range:NSMakeRange(0, cssValue.length)];
-
+    
     for (NSTextCheckingResult *match in matches) {
         NSString *name = [cssValue substringWithRange:[match rangeAtIndex:1]];
         NSArray *value = [[cssValue substringWithRange:[match rangeAtIndex:2]] componentsSeparatedByString:@","];
-
-        SEL method = NSSelectorFromString([NSString stringWithFormat:@"do%@:", [name capitalizedString]]);
+        
+        SEL method = NSSelectorFromString([NSString stringWithFormat:@"parse%@:", [name capitalizedString]]);
         if ([self respondsToSelector:method]) {
             @try {
                 [self performSelectorOnMainThread:method withObject:value waitUntilDone:YES];
@@ -68,88 +170,121 @@
             }
         }
     }
-
-    return CATransform3DMakeAffineTransform(_transform);
 }
 
-- (CATransform3D)getTransform:(NSString *)cssValue withView:(UIView *)view
+- (void)parseTransformOrigin:(NSString *)cssValue
 {
-    _view = view;
-    CATransform3D transform = [self getTransform:cssValue];
-    _view = nil;
-    return transform;
-}
-
-- (CATransform3D)getTransform:(NSString *)cssValue withView:(UIView *)view withOrigin:(NSString *)origin
-{
-    if (origin && origin.length > 0 && ![origin isEqualToString:@"none"]) {
-        /**
-          * Waiting to fix the issue that transform-origin behaves in rotation 
-          * http://ronnqvi.st/translate-rotate-translate/
-         **/
-        CGPoint originPoint = [self getTransformOrigin:origin withView:view];
-        if (originPoint.x != 0 || originPoint.y != 0) {
-            cssValue = [NSString stringWithFormat:@"translate(%f,%f) %@ translate(%f,%f)", originPoint.x, originPoint.y, cssValue, -originPoint.x, -originPoint.y];
-        }
+    if (!cssValue || cssValue.length == 0 || [cssValue isEqualToString:@"none"]) {
+        return;
     }
     
-    return [self getTransform:cssValue withView:view];
-}
-
-- (CATransform3D)getTransform:(NSString *)cssValue withView:(UIView *)view withOrigin:(NSString *)origin isTransformRotate:(BOOL)isTransformRotate
-{
-    _isTransformRotate = isTransformRotate;
-    return [self getTransform:cssValue withView:view withOrigin:origin];
-}
-
-- (CGPoint)getTransformOrigin:(NSString *)cssValue withView:(UIView *)view
-{
     NSArray *values = [cssValue componentsSeparatedByString:@" "];
-    double width = view.bounds.size.width;
-    double height = view.bounds.size.height;
-    double x = width / 2;
-    double y = height / 2;
 
+    double originX = 50;
+    double originY = 50;
+    WXLengthType typeX = WXLengthTypePercent;
+    WXLengthType typeY = WXLengthTypePercent;
     for (NSInteger i = 0; i < values.count; i++) {
         NSString *value = values[i];
         if ([value isEqualToString:@"left"]) {
-            x = 0;
+            originX = 0;
         } else if ([value isEqualToString:@"right"]) {
-            x = width;
+            originX = 100;
         } else if ([value isEqualToString:@"top"]) {
-            y = 0;
+            originY = 0;
         } else if ([value isEqualToString:@"bottom"]) {
-            y = height;
+            originY = 100;
         } else if ([value isEqualToString:@"center"]) {
             if (i == 0) {
-                x = width / 2;
+                originX = 50;
             } else {
-                y = height / 2;
+                originY = 50;
             }
         } else {
             double val = [value doubleValue];
             if (i == 0) {
                 if ([value hasSuffix:@"%"]) {
-                    val *= width / 100;
+                    originX = val;
                 } else {
-                    val = WXPixelScale(val, self.weexInstance.pixelScaleFactor);
+                    typeX = WXLengthTypeFixed;
+                    originX = WXPixelScale(val, self.weexInstance.pixelScaleFactor);
                 }
-                x = val;
             } else {
                 if ([value hasSuffix:@"%"]) {
-                    val *= height / 100;
+                    originY = val;
                 } else {
-                    val = WXPixelScale(val, self.weexInstance.pixelScaleFactor);
+                    typeY = WXLengthTypeFixed;
+                    originY = WXPixelScale(val, self.weexInstance.pixelScaleFactor);
                 }
-                y = val;
             }
         }
     }
-    x -= width / 2.0;
-    y -= height / 2.0;
     
-    CGFloat scaleFactor = self.weexInstance.pixelScaleFactor;
-    return CGPointMake(round(x / scaleFactor), round(y / scaleFactor));
+    _originX = [WXLength lengthWithValue:originX type:typeX];
+    _originY = [WXLength lengthWithValue:originY type:typeY];
+}
+
+- (void)parseRotate:(NSArray *)value
+{
+    float rotateAngle = [self getAngle:value[0]];
+    _rotateAngle = rotateAngle;
+}
+
+- (void)parseTranslate:(NSArray *)value
+{
+    WXLength *translateX;
+    double x = [value[0] doubleValue];
+    if ([value[0] hasSuffix:@"%"]) {
+        translateX = [WXLength lengthWithValue:x type:WXLengthTypePercent];
+    } else {
+        x = WXPixelScale(x, self.weexInstance.pixelScaleFactor);
+        translateX = [WXLength lengthWithValue:x type:WXLengthTypeFixed];
+    }
+
+    WXLength *translateY;
+    if (value.count > 1) {
+        double y = [value[1] doubleValue];
+        if ([value[1] hasSuffix:@"%"]) {
+            translateY = [WXLength lengthWithValue:y type:WXLengthTypePercent];
+        } else {
+            y = WXPixelScale(y, self.weexInstance.pixelScaleFactor);
+            translateY = [WXLength lengthWithValue:y type:WXLengthTypeFixed];
+        }
+    }
+    
+    _translateX = translateX;
+    _translateY = translateY;
+}
+
+- (void)parseTranslatex:(NSArray *)value
+{
+    [self parseTranslate:@[value[0], @"0"]];
+}
+
+- (void)parseTranslatey:(NSArray *)value
+{
+    [self parseTranslate:@[@"0", value[0]]];
+}
+
+- (void)parseScale:(NSArray *)value
+{
+    double x = [value[0] doubleValue];
+    double y = x;
+    if (value.count == 2) {
+        y = [value[1] doubleValue];
+    }
+    _scaleX = x;
+    _scaleY = y;
+}
+
+- (void)parseScalex:(NSArray *)value
+{
+    [self parseScale:@[value[0], @1]];
+}
+
+- (void)parseScaley:(NSArray *)value
+{
+    [self parseScale:@[@1, value[0]]];
 }
 
 // Angle in radians
@@ -157,109 +292,15 @@
 {
     double angle = [value doubleValue];
     if ([value hasSuffix:@"deg"]) {
-        angle *= M_PI / 180;
-    }
-    return angle;
-}
-
-// css transfrom
-- (void)doTranslate:(NSArray *)value
-{
-    double x = [value[0] doubleValue];
-    if ([value[0] hasSuffix:@"%"] && _view) {
-        x *= _view.bounds.size.width / 100;
+        return [self deg2rad:angle];
     } else {
-        x = WXPixelScale(x, self.weexInstance.pixelScaleFactor);
+        return angle;
     }
-
-    double y = 0;
-
-    if (value.count > 1) {
-        y = [value[1] doubleValue];
-        if ([value[1] hasSuffix:@"%"] && _view) {
-            y *= _view.bounds.size.height / 100;
-        } else {
-            y = WXPixelScale(y, self.weexInstance.pixelScaleFactor);
-        }
-    }
-    _transform = CGAffineTransformTranslate(_transform, x, y);
 }
 
-- (void)doTranslatex:(NSArray *)value
+- (double)deg2rad:(double)deg
 {
-    [self doTranslate:@[value[0], @"0"]];
-}
-
-- (void)doTranslatey:(NSArray *)value
-{
-    [self doTranslate:@[@"0", value[0]]];
-}
-
-- (void)doRotate:(NSArray *)value
-{
-    float rotateAngle = [self getAngle:value[0]];
-    CGAffineTransform cgTransform = CATransform3DGetAffineTransform(_view.layer.transform);
-    float originAngle = atan2f(cgTransform.b, cgTransform.a);
-    originAngle = originAngle < 0 ? originAngle + 2 * M_PI : originAngle;
-    if (_isTransformRotate || fabs(rotateAngle - originAngle) <= M_PI+0.0001){
-        _transform = CGAffineTransformRotate(_transform, rotateAngle);
-    } else if (originAngle != 0) {
-        _transform = CGAffineTransformRotate(_transform, originAngle);
-    }
-
-    _rotateAngle += rotateAngle;
-}
-
-- (float)getRotateAngle
-{
-    return _rotateAngle;
-}
-
-- (void)doScale:(NSArray *)value
-{
-    double x = [value[0] doubleValue];
-    double y = x;
-    if (value.count == 2) {
-        y = [value[1] doubleValue];
-    }
-    _transform = CGAffineTransformScale(_transform, x, y);
-}
-
-- (void)doScalex:(NSArray *)value
-{
-    [self doScale:@[value[0], @1]];
-}
-
-- (void)doScaley:(NSArray *)value
-{
-    [self doScale:@[@1, value[0]]];
-}
-
-- (void)doSkew:(NSArray *)value
-{
-    CGAffineTransform skew = CGAffineTransformIdentity;
-    skew.c = tan([self getAngle:value[0]]);
-    if (value.count == 2) {
-        skew.b = tan([self getAngle:value[1]]);
-    }
-    _transform = CGAffineTransformConcat(skew, _transform);
-}
-
-- (void)doSkewx:(NSArray *)value
-{
-    [self doSkew:@[value[0], @0]];
-}
-
-- (void)doSkewy:(NSArray *)value
-{
-    [self doSkew:@[@0, value[0]]];
-}
-
-- (void)doMatrix:(NSArray *) value
-{
-    if (value.count < 6) return;
-    
-    _transform = CGAffineTransformConcat(CGAffineTransformMake([value[0] doubleValue], [value[1] doubleValue], [value[2] doubleValue], [value[3] doubleValue], [value[4] doubleValue], [value[5] doubleValue]), _transform);
+    return deg * M_PI / 180.0;
 }
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -119,8 +119,7 @@
             strongSelf.view.frame = strongSelf.calculatedFrame;
             
             if (strongSelf->_transform) {
-                WXTransform *transform = [[WXTransform alloc] initWithInstance:strongSelf.weexInstance];
-                strongSelf.layer.transform = [transform getTransform:strongSelf->_transform withView:strongSelf.view withOrigin:strongSelf->_transformOrigin];
+                [strongSelf->_transform applyTransformForView:strongSelf.view];
             }
             
             [strongSelf setNeedsDisplay];

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
@@ -207,7 +207,7 @@
         }
         
         if (_transform) {
-            _layer.transform = [[[WXTransform alloc] initWithInstance:self.weexInstance] getTransform:_transform withView:_view withOrigin:_transformOrigin];
+            [_transform applyTransformForView:_view];
         }
         
         _view.wx_component = self;

--- a/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
@@ -45,7 +45,12 @@
 
 @end
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
+// CAAnimationDelegate is not available before iOS 10 SDK
+@interface WXAnimationDelegate ()
+#else
 @interface WXAnimationDelegate : NSObject <CAAnimationDelegate>
+#endif
 
 @property (nonatomic, copy) void (^finishBlock)(BOOL);
 @property (nonatomic, strong) WXAnimationInfo *animationInfo;

--- a/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
@@ -45,12 +45,7 @@
 
 @end
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
-// CAAnimationDelegate is not available before iOS 10 SDK
-@interface WXAnimationDelegate ()
-#else
 @interface WXAnimationDelegate : NSObject <CAAnimationDelegate>
-#endif
 
 @property (nonatomic, copy) void (^finishBlock)(BOOL);
 @property (nonatomic, strong) WXAnimationInfo *animationInfo;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXAssert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXAssert.h
@@ -63,4 +63,7 @@ WXAssert([[NSThread currentThread].name isEqualToString:WX_BRIDGE_THREAD_NAME], 
 @"must be called on the bridge thread")
 
 
+#define WXAssertNotReached() \
+WXAssert(NO, @"should never be reached")
+
 WX_EXTERN_C_END

--- a/ios/sdk/WeexSDK/Sources/Utility/WXLength.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXLength.h
@@ -1,0 +1,31 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef enum : NSUInteger {
+    WXLengthTypeFixed,
+    WXLengthTypePercent,
+    WXLengthTypeAuto,
+} WXLengthType;
+
+@interface WXLength : NSObject
+
++ (instancetype)lengthWithValue:(float)value type:(WXLengthType)type;
+
+- (float)valueForMaximumValue:(float)maximumValue;
+
+- (BOOL)isEqualToLength:(WXLength *)length;
+
+- (BOOL)isFixed;
+
+- (BOOL)isPercent;
+
+- (BOOL)isAuto;
+
+@end

--- a/ios/sdk/WeexSDK/Sources/Utility/WXLength.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXLength.m
@@ -1,0 +1,61 @@
+/**
+ * Created by Weex.
+ * Copyright (c) 2016, Alibaba, Inc. All rights reserved.
+ *
+ * This source code is licensed under the Apache Licence 2.0.
+ * For the full copyright and license information,please view the LICENSE file in the root directory of this source tree.
+ */
+
+#import "WXLength.h"
+#import "WXAssert.h"
+
+@implementation WXLength
+{
+    float _value;
+    WXLengthType _type;
+}
+
++ (instancetype)lengthWithValue:(float)value type:(WXLengthType)type
+{
+    WXLength *length = [WXLength new];
+    length->_value = value;
+    length->_type = type;
+    return length;
+}
+
+- (float)valueForMaximumValue:(float)maximumValue
+{
+    switch (_type) {
+        case WXLengthTypeFixed:
+            return _value;
+        case WXLengthTypePercent:
+            return maximumValue * _value / 100.0;
+        case WXLengthTypeAuto:
+            return maximumValue;
+        default:
+            WXAssertNotReached();
+            return 0;
+    }
+}
+
+- (BOOL)isEqualToLength:(WXLength *)length
+{
+    return length && _type == length->_type && _value == length->_value;
+}
+
+- (BOOL)isFixed
+{
+    return _type == WXLengthTypeFixed;
+}
+
+- (BOOL)isPercent
+{
+    return _type == WXLengthTypePercent;
+}
+
+- (BOOL)isAuto
+{
+    return _type == WXLengthTypeAuto;
+}
+
+@end

--- a/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.m
+++ b/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.m
@@ -99,8 +99,9 @@
     _clipToBounds = styles[@"overflow"] ? [WXConvert WXClipType:styles[@"overflow"]] : NO;
     _visibility = styles[@"visibility"] ? [WXConvert WXVisibility:styles[@"visibility"]] : WXVisibilityShow;
     _positionType = styles[@"position"] ? [WXConvert WXPositionType:styles[@"position"]] : WXPositionTypeRelative;
-    _transform = styles[@"transform"] ? [WXConvert NSString:styles[@"transform"]] : nil;
-    _transformOrigin = styles[@"transformOrigin"] ? [WXConvert NSString:styles[@"transformOrigin"]] : nil;
+    _transform = styles[@"transform"] || styles[@"transformOrigin"] ?
+    [[WXTransform alloc] initWithCSSValue:[WXConvert NSString:styles[@"transform"]] origin:styles[@"transformOrigin"] instance:self.weexInstance] :
+    [[WXTransform alloc] initWithCSSValue:nil origin:nil instance:self.weexInstance];
 }
 
 - (void)_updateViewStyles:(NSDictionary *)styles
@@ -160,14 +161,10 @@
         }
     }
     
-    if (styles[@"transformOrigin"]) {
-        _transformOrigin = [WXConvert NSString:styles[@"transformOrigin"]];
-    }
-    
-    if (styles[@"transform"]) {
+    if (styles[@"transformOrigin"] || styles[@"transform"]) {
+        _transform = [[WXTransform alloc] initWithCSSValue:[WXConvert NSString:styles[@"transform"]] origin:styles[@"transformOrigin"] instance:self.weexInstance];
         if (!CGRectEqualToRect(self.calculatedFrame, CGRectZero)) {
-            _transform = [WXConvert NSString:styles[@"transform"]];
-            _layer.transform = [[[WXTransform alloc] initWithInstance:self.weexInstance] getTransform:_transform withView:_view withOrigin:_transformOrigin];
+            [_transform applyTransformForView:_view];
             [_layer setNeedsDisplay];
         }
     }

--- a/ios/sdk/WeexSDK/Sources/WeexSDK.h
+++ b/ios/sdk/WeexSDK/Sources/WeexSDK.h
@@ -18,6 +18,8 @@
 #import "WXSDKError.h"
 #import "WXSDKEngine.h"
 #import "WXRootViewController.h"
+#import "WXResourceResponse.h"
+#import "WXResourceRequestHandler.h"
 #import "WXResourceRequest.h"
 #import "WXNetworkProtocol.h"
 #import "WXNavigationProtocol.h"


### PR DESCRIPTION
### Refactor transform and transition
  * UIView animation does not support rotation animation whose degree > 180，so we use CAAnimation to hack it.
  * Using UIView animation along with CAAnimation has a lot of problems when developers use rotate/scale/translate together
  * We refactor all transition properties to use CAAnimation to ensure consistency
  * We also separate transform string parsing with runtime parsing to ensure performance
  * tested demos:
     * all the demos in playground and tests 
     * http://dotwe.org/weex/7d8e99a7d5dc8ee22e2437d6d8513fec
     * http://dotwe.org/weex/cad4d4cd051ab3e565f3cd42bbcac73b
     * http://dotwe.org/weex/8cfadb65d744fd400728097ef7da3bcc
 * related issue: #1596 #2070 #2182 #2226 