### PR TITLE
Ios feature 20170118 scroll offset

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -41,11 +41,13 @@
 {
     CGSize _contentSize;
     BOOL _listenLoadMore;
+    BOOL _scrollEvent;
     CGFloat _loadMoreOffset;
     CGFloat _previousLoadMoreContentHeight;
+    CGFloat _offsetAccuracy;
     CGPoint _lastContentOffset;
     BOOL _scrollable;
-    
+
     // vertical & horizontal
     WXScrollDirection _scrollDirection;
     // left & right & up & down
@@ -86,14 +88,14 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         
         _stickyArray = [NSMutableArray array];
         _listenerArray = [NSMutableArray array];
-        
+        _scrollEvent = NO;
         _scrollDirection = attributes[@"scrollDirection"] ? [WXConvert WXScrollDirection:attributes[@"scrollDirection"]] : WXScrollDirectionVertical;
         _showScrollBar = attributes[@"showScrollbar"] ? [WXConvert BOOL:attributes[@"showScrollbar"]] : YES;
         _loadMoreOffset = attributes[@"loadmoreoffset"] ? [WXConvert CGFloat:attributes[@"loadmoreoffset"]] : 0;
         _loadmoreretry = attributes[@"loadmoreretry"] ? [WXConvert NSUInteger:attributes[@"loadmoreretry"]] : 0;
         _listenLoadMore = [events containsObject:@"loadmore"];
         _scrollable = attributes[@"scrollable"] ? [WXConvert BOOL:attributes[@"scrollable"]] : YES;
-
+        _offsetAccuracy = attributes[@"offsetAccuracy"] ? [WXConvert CGFloat:attributes[@"offsetAccuracy"]] : 0;
         _scrollerCSSNode = new_css_node();
         
         // let scroller fill the rest space if it is a child component and has no fixed height & width
@@ -181,12 +183,18 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         _scrollable = attributes[@"scrollable"] ? [WXConvert BOOL:attributes[@"scrollable"]] : YES;
         ((UIScrollView *)self.view).scrollEnabled = _scrollable;
     }
+    if (attributes[@"offsetAccuracy"]) {
+        _offsetAccuracy = [WXConvert CGFloat:attributes[@"offsetAccuracy"]];
+    }
 }
 
 - (void)addEvent:(NSString *)eventName
 {
     if ([eventName isEqualToString:@"loadmore"]) {
         _listenLoadMore = YES;
+    }
+    if ([eventName isEqualToString:@"scroll"]) {
+        _scrollEvent = YES;
     }
 }
 
@@ -412,8 +420,6 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         _direction = @"up";
     }
     
-    _lastContentOffset = scrollView.contentOffset;
-    
     // check sticky
     [self adjustSticky];
     [self handleLoadMore];
@@ -433,6 +439,23 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     if (self.onScroll) {
         self.onScroll(scrollView);
     }
+    if (_scrollEvent) {
+        NSMutableDictionary *scrollEventParams = [[NSMutableDictionary alloc] init];
+        NSDictionary *frameSizeData = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithFloat:scrollView.frame.size.width],@"width",[NSNumber numberWithFloat:scrollView.frame.size.height],@"height", nil];
+        NSDictionary *contentSizeData = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithFloat:scrollView.contentSize.width],@"width",[NSNumber numberWithFloat:scrollView.contentSize.height],@"height", nil];
+        //contentOffset values are replaced by (-contentOffset.x,-contentOffset.y) ,in order to be consistent with Android client.
+        NSDictionary *contentOffsetData = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithFloat:-scrollView.contentOffset.x],@"x",[NSNumber numberWithFloat:-scrollView.contentOffset.y],@"y", nil];
+        float distance = 0;
+        if (_scrollDirection == WXScrollDirectionHorizontal) {
+            distance = scrollView.contentOffset.x - _lastContentOffset.x;
+        } else {
+            distance = scrollView.contentOffset.y - _lastContentOffset.y;
+        }
+        if (ABS(distance) >= _offsetAccuracy) {
+            [self fireEvent:@"scroll" params:@{@"frameSize":frameSizeData,@"contentSize":contentSizeData,@"contentOffset":contentOffsetData} domChanges:nil];
+        }
+    }
+    _lastContentOffset = scrollView.contentOffset;
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView


### PR DESCRIPTION
<!--
It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

---

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。
-->
scroller添加onscroll事件，根据属性中设置的offsetAccuracy进行采样回传滚动事件。
事件中返回三个参数：1、frameSize：width,height。2、contentSize：width,height。3、contentOffset：x,y。 此事件默认不发出，只有设置scroll事件监听时才触发。contentOffset 与安卓保持一致，是scrollview.contentOffset的x，y分别取负得到。
示例demo:http://dotwe.org/weex/5837c1b7f1f69e5adf1fc4cac0747c34