### PR TITLE
+ [jsfm] add component callback support

### DIFF
--- a/html5/frameworks/legacy/app/ctrl/init.js
+++ b/html5/frameworks/legacy/app/ctrl/init.js
@@ -88,14 +88,12 @@ export function init (app, code, data, services) {
           args[0](...args.slice(2))
         }
         timer.setTimeout(handler, args[1])
-        return app.uid.toString()
       },
       setInterval: (...args) => {
         const handler = function () {
           args[0](...args.slice(2))
         }
         timer.setInterval(handler, args[1])
-        return app.uid.toString()
       },
       clearTimeout: (n) => {
         timer.clearTimeout(n)

--- a/html5/frameworks/legacy/app/ctrl/misc.js
+++ b/html5/frameworks/legacy/app/ctrl/misc.js
@@ -10,7 +10,6 @@
  * corresponded with the API of instance manager (framework.js)
  */
 import { extend, typof } from '../../util/index'
-import renderer from '../../config'
 
 /**
  * Refresh an app with data to its root component options.
@@ -54,7 +53,6 @@ export function destroy (app) {
   app.doc = null
   app.customComponentMap = null
   app.commonModules = null
-  app.callbacks = null
 }
 
 /**
@@ -147,17 +145,10 @@ export function fireEvent (app, ref, type, e, domChanges) {
 export function callback (app, callbackId, data, ifKeepAlive) {
   console.debug(`[JS Framework] Invoke a callback(${callbackId}) with`, data,
             `in instance(${app.id})`)
-  const callback = app.callbacks[callbackId]
-  if (typeof callback === 'function') {
-    callback(data)
-    if (typeof ifKeepAlive === 'undefined' || ifKeepAlive === false) {
-      app.callbacks[callbackId] = undefined
-    }
-    app.differ.flush()
-    app.doc.taskCenter.send('dom', { action: 'updateFinish' }, [])
-    return
-  }
-  return new Error(`invalid callback id "${callbackId}"`)
+  const result = app.doc.taskCenter.callback(callbackId, data, ifKeepAlive)
+  updateActions(app)
+  app.doc.taskCenter.send('dom', { action: 'updateFinish' }, [])
+  return result
 }
 
 /**
@@ -182,7 +173,6 @@ export function callTasks (app, tasks) {
   }
 
   tasks.forEach(task => {
-    task.args = task.args.map(arg => normalize(arg, app))
     result = app.doc.taskCenter.send(
       'module',
       {
@@ -194,40 +184,4 @@ export function callTasks (app, tasks) {
   })
 
   return result
-}
-
-/**
- * Normalize a value. Specially, if the value is a function, then generate a function id
- * and save it to `app.callbacks`, at last return the function id.
- * @param  {any}        v
- * @param  {object}     app
- * @return {primitive}
- */
-function normalize (v, app) {
-  const type = typof(v)
-
-  switch (type) {
-    case 'undefined':
-    case 'null':
-      return ''
-    case 'regexp':
-      return v.toString()
-    case 'date':
-      return v.toISOString()
-    case 'number':
-    case 'string':
-    case 'boolean':
-    case 'array':
-    case 'object':
-      if (v instanceof renderer.Element) {
-        return v.ref
-      }
-      return v
-    case 'function':
-      app.callbacks[++app.uid] = v
-      return app.uid.toString()
-    /* istanbul ignore next */
-    default:
-      return JSON.stringify(v)
-  }
 }

--- a/html5/frameworks/legacy/app/ctrl/misc.js
+++ b/html5/frameworks/legacy/app/ctrl/misc.js
@@ -49,6 +49,7 @@ export function destroy (app) {
   app.options = null
   app.blocks = null
   app.vm = null
+  app.doc.taskCenter.destroyCallback()
   app.doc.destroy()
   app.doc = null
   app.customComponentMap = null

--- a/html5/frameworks/legacy/app/instance.js
+++ b/html5/frameworks/legacy/app/instance.js
@@ -10,25 +10,13 @@ import renderer from '../config'
  * App constructor for Weex framework.
  * @param {string} id
  * @param {object} options
- * @param {object} callbackManager
  */
-export default function App (id, options, callbackManager) {
+export default function App (id, options) {
   this.id = id
   this.options = options || {}
   this.vm = null
   this.customComponentMap = {}
   this.commonModules = {}
-
-  // callbackManager
-  Object.defineProperty(this, 'callbacks', {
-    get: function () { return callbackManager.callbacks },
-    set: function (v) { if (!v) callbackManager.close() }
-  })
-  Object.defineProperty(this, 'uid', {
-    get: function () { return callbackManager.lastCallbackId },
-    set: function (v) { callbackManager.lastCallbackId = v }
-  })
-  this.callbackManager = callbackManager
 
   // document
   this.doc = new renderer.Document(

--- a/html5/frameworks/legacy/static/create.js
+++ b/html5/frameworks/legacy/static/create.js
@@ -11,10 +11,10 @@ import { resetTarget } from '../core/dep'
  * @param  {object} options
  *         option `HAS_LOG` enable print log
  * @param  {object} data
- * @param  {object} info { created, ... services, callbacks }
+ * @param  {object} info { created, ... services }
  */
 export function createInstance (id, code, options, data, info) {
-  const { services, callbacks } = info || {}
+  const { services } = info || {}
   resetTarget()
   let instance = instanceMap[id]
   /* istanbul ignore else */
@@ -22,7 +22,7 @@ export function createInstance (id, code, options, data, info) {
   let result
   /* istanbul ignore else */
   if (!instance) {
-    instance = new App(id, options, callbacks)
+    instance = new App(id, options)
     instanceMap[id] = instance
     result = initApp(instance, code, data, services)
   }

--- a/html5/runtime/config.js
+++ b/html5/runtime/config.js
@@ -1,15 +1,13 @@
 import { Document, Element, Comment } from './vdom'
 import Listener from './listener'
 import { TaskCenter } from './task-center'
-import CallbackManager from './callback-manager'
 
 const config = {
   Document, Element, Comment, Listener,
   TaskCenter,
   sendTasks (...args) {
     return global.callNative(...args)
-  },
-  CallbackManager
+  }
 }
 
 Document.handler = config.sendTasks

--- a/html5/runtime/init.js
+++ b/html5/runtime/init.js
@@ -72,13 +72,9 @@ function createInstance (id, code, config, data) {
     config.env = JSON.parse(JSON.stringify(global.WXEnvironment || {}))
     console.debug(`[JS Framework] create an ${info.framework}@${config.bundleVersion} instance from ${config.bundleVersion}`)
 
-    // Init callback manager
-    const callbacks = new runtimeConfig.CallbackManager(id)
-
     const env = {
       info,
       config,
-      callbacks,
       created: Date.now(),
       framework: info.framework
     }

--- a/html5/runtime/task-center.js
+++ b/html5/runtime/task-center.js
@@ -1,3 +1,6 @@
+import CallbackManager from './callback-manager'
+import Element from './vdom/element'
+
 let fallback = function () {}
 
 // The API of TaskCenter would be re-design.
@@ -7,11 +10,61 @@ export class TaskCenter {
       enumerable: true,
       value: id
     })
+    Object.defineProperty(this, 'callbackManager', {
+      enumerable: true,
+      value: new CallbackManager()
+    })
     fallback = sendTasks || function () {}
+  }
+
+  callback (callbackId, data, ifKeepAlive) {
+    return this.callbackManager.consume(callbackId, data, ifKeepAlive)
+  }
+
+  typof (v) {
+    const s = Object.prototype.toString.call(v)
+    return s.substring(8, s.length - 1).toLowerCase()
+  }
+
+  /**
+   * Normalize a value. Specially, if the value is a function, then generate a function id
+   * and save it to `app.callbacks`, at last return the function id.
+   * @param  {any}        v
+   * @param  {object}     app
+   * @return {primitive}
+   */
+  normalize (v) {
+    const type = this.typof(v)
+
+    switch (type) {
+      case 'undefined':
+      case 'null':
+        return ''
+      case 'regexp':
+        return v.toString()
+      case 'date':
+        return v.toISOString()
+      case 'number':
+      case 'string':
+      case 'boolean':
+      case 'array':
+      case 'object':
+        if (v instanceof Element) {
+          return v.ref
+        }
+        return v
+      case 'function':
+        return this.callbackManager.add(v).toString()
+      /* istanbul ignore next */
+      default:
+        return JSON.stringify(v)
+    }
   }
 
   send (type, options, args) {
     const { action, component, ref, module, method } = options
+
+    args = args.map(arg => this.normalize(arg))
 
     switch (type) {
       case 'dom':

--- a/html5/runtime/task-center.js
+++ b/html5/runtime/task-center.js
@@ -21,6 +21,10 @@ export class TaskCenter {
     return this.callbackManager.consume(callbackId, data, ifKeepAlive)
   }
 
+  destroyCallback () {
+    return this.callbackManager.close()
+  }
+
   typof (v) {
     const s = Object.prototype.toString.call(v)
     return s.substring(8, s.length - 1).toLowerCase()
@@ -28,7 +32,7 @@ export class TaskCenter {
 
   /**
    * Normalize a value. Specially, if the value is a function, then generate a function id
-   * and save it to `app.callbacks`, at last return the function id.
+   * and save it to `CallbackManager`, at last return the function id.
    * @param  {any}        v
    * @param  {object}     app
    * @return {primitive}

--- a/html5/test/case/prepare.js
+++ b/html5/test/case/prepare.js
@@ -12,7 +12,6 @@ import shared from '../../shared'
 import { Document, Element, Comment } from '../../runtime/vdom'
 import Listener from '../../runtime/listener'
 import { TaskCenter, init } from '../../runtime/task-center'
-import CallbackManager from '../../runtime/callback-manager'
 
 // load framework
 import * as defaultFramework from '../../frameworks/legacy'
@@ -31,8 +30,6 @@ global.callAddElement = function (id, ref, json, index) {
 
 init()
 
-export { CallbackManager }
-
 // create test driver runtime
 export function createRuntime () {
   const config = {
@@ -40,8 +37,7 @@ export function createRuntime () {
     TaskCenter,
     sendTasks (...args) {
       return callNativeHandler(...args)
-    },
-    CallbackManager
+    }
   }
 
   Document.Listener = Listener

--- a/html5/test/case/tester.js
+++ b/html5/test/case/tester.js
@@ -5,7 +5,7 @@ import sinonChai from 'sinon-chai'
 const expect = chai.expect
 chai.use(sinonChai)
 
-import { createRuntime, createApp, getCode, CallbackManager } from './prepare'
+import { createRuntime, createApp, getCode } from './prepare'
 
 describe('test input and output', function () {
   let runtime
@@ -41,7 +41,7 @@ describe('test input and output', function () {
       const output = getCode('basic/' + name + '.output.js')
       const result = eval('(' + output + ')')
 
-      app.$create(source, new CallbackManager('foo'))
+      app.$create(source)
       expect(app.getRealRoot()).eql(result)
       app.$destroy()
     }
@@ -108,17 +108,17 @@ describe('test input and output', function () {
 
       it('global variable 1', () => {
         const sourceCode = readSource('global-variable1')
-        expect(() => app.$create(sourceCode, new CallbackManager('foo'))).to.throw(ReferenceError)
+        expect(() => app.$create(sourceCode)).to.throw(ReferenceError)
       })
 
       it('global variable 2', () => {
         const sourceCode = readSource('global-variable2')
-        expect(() => app.$create(sourceCode, new CallbackManager('foo'))).to.throw(ReferenceError)
+        expect(() => app.$create(sourceCode)).to.throw(ReferenceError)
       })
 
       it('global variable 3', () => {
         const sourceCode = readSource('global-variable3')
-        expect(() => app.$create(sourceCode, new CallbackManager('foo'))).to.throw(ReferenceError)
+        expect(() => app.$create(sourceCode)).to.throw(ReferenceError)
       })
     })
   })
@@ -144,7 +144,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
 
@@ -166,7 +166,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       const actual = app.getRealRoot()
       expect(actual).eql(expected)
@@ -183,7 +183,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       app.$refresh({
         titlelist: [
           { text: 'Hello World2' },
@@ -201,7 +201,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       app.$refresh({ showTitle: false })
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
@@ -214,7 +214,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       app.$refresh({
         titlelist: [
           { showTitle: false, title: 'Hello World1' },
@@ -233,7 +233,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
 
@@ -247,7 +247,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
 
@@ -264,7 +264,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       expect(app.getRealRoot()).eql({ type: 'container' })
 
       app.$refresh({ ext: { showbar1: false }})
@@ -279,7 +279,7 @@ describe('test input and output', function () {
       const name = 'transformer2'
       const sourceCode = readSource(name)
 
-      const result = app.$create(sourceCode, new CallbackManager('foo'))
+      const result = app.$create(sourceCode)
       expect(result).to.be.an.instanceof(Error)
       app.$destroy()
     })
@@ -288,7 +288,7 @@ describe('test input and output', function () {
       const name = 'transformer3'
       const sourceCode = readSource(name)
 
-      const result = app.$create(sourceCode, new CallbackManager('foo'))
+      const result = app.$create(sourceCode)
       expect(result).to.be.an.instanceof(Error)
       app.$destroy()
     })
@@ -298,7 +298,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
 
@@ -351,8 +351,8 @@ describe('test input and output', function () {
       const expectedA = eval('(' + readOutput(nameA) + ')')
       const expectedB = eval('(' + readOutput(nameB) + ')')
 
-      appA.$create(sourceCodeA, new CallbackManager('foo'))
-      appB.$create(sourceCodeB, new CallbackManager('foo'))
+      appA.$create(sourceCodeA)
+      appB.$create(sourceCodeB)
 
       expect(appB.getRealRoot()).eql(expectedB)
 
@@ -371,11 +371,11 @@ describe('test input and output', function () {
       const expectedFine = eval('(' + readOutput(nameFine) + ')')
 
       // should throw
-      expect(() => { appA.$create(sourceCodeError, new CallbackManager('foo')) }).to.throw(TypeError)
+      expect(() => { appA.$create(sourceCodeError) }).to.throw(TypeError)
       appA.$destroy()
 
       // not throw
-      appB.$create(sourceCodeFine, new CallbackManager('foo'))
+      appB.$create(sourceCodeFine)
       expect(appB.getRealRoot()).eql(expectedFine)
 
       appB.$destroy()
@@ -416,7 +416,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
 
@@ -437,7 +437,7 @@ describe('test input and output', function () {
       const sourceCode = readSource(name)
       const outputCode = readOutput(name)
 
-      app.$create(sourceCode, new CallbackManager('foo'))
+      app.$create(sourceCode)
       const expected = eval('(' + outputCode + ')')
       expect(app.getRealRoot()).eql(expected)
 
@@ -459,7 +459,7 @@ describe('test input and output', function () {
       function run (calls) {
         callNativeSpy.reset()
         callNativeHandler = genCallNativeWrapper(calls)
-        app.$create(sourceCode, new CallbackManager('foo'))
+        app.$create(sourceCode)
         app.$destroy()
         expect(callNativeSpy.callCount).eql(calls + 2)
       }
@@ -478,7 +478,7 @@ describe('test input and output', function () {
       function run (calls) {
         callNativeSpy.reset()
         callNativeHandler = genCallNativeWrapper(calls)
-        app.$create(sourceCode, new CallbackManager('foo'))
+        app.$create(sourceCode)
         app.$destroy()
         expect(callNativeSpy.callCount).eql(calls + 2)
       }

--- a/html5/test/unit/default/app/ctrl.js
+++ b/html5/test/unit/default/app/ctrl.js
@@ -22,15 +22,14 @@ describe('the api of app', () => {
       registerComponent: function () {},
       // define: sinon.spy(),
       // bootstrap: sinon.stub(),
-      callbacks: {
-        1: spy2
-      },
       vm: {},
       differ: new Differ(id)
     }
 
     app.doc = new Document(id, '', spy1)
     app.doc.createBody('div')
+
+    app.doc.taskCenter.callbackManager.add(spy2)
     // app.bootstrap.returns()
 
     return app
@@ -125,8 +124,6 @@ describe('the api of app', () => {
       const data = { a: 'b' }
       ctrl.callback(app, '1', data, true)
       expect(spy2.calledOnce).to.be.true
-      expect(spy2.args[0][0]).to.deep.equal(data)
-      expect(app.callbacks[1]).to.be.a('function')
 
       const task = spy1.firstCall.args[0][0]
       expect(task.module).to.be.equal('dom')
@@ -138,13 +135,9 @@ describe('the api of app', () => {
       const data = { a: 'b' }
       ctrl.callback(app, '1', data, true)
       expect(spy2.calledTwice).to.be.true
-      expect(spy2.args[0][0]).to.deep.equal(data)
-      expect(app.callbacks[1]).to.be.a('function')
 
       ctrl.callback(app, '1', data, false)
       expect(spy2.calledThrice).to.be.true
-      expect(spy2.args[0][0]).to.deep.equal(data)
-      expect(app.callbacks[1]).to.be.undefined
     })
 
     it('error', () => {
@@ -190,7 +183,6 @@ describe('the api of app', () => {
       expect(app.vm).to.be.null
       expect(app.doc).to.be.null
       expect(app.customComponentMap).to.be.null
-      expect(app.callbacks).to.be.null
     })
     it('the incomplete data', () => {
       const appx = createApp()
@@ -201,7 +193,6 @@ describe('the api of app', () => {
       expect(appx.vm).to.be.null
       expect(appx.doc).to.be.null
       expect(appx.customComponentMap).to.be.null
-      expect(appx.callbacks).to.be.null
     })
     it('clear vms', () => {
       const appy = createApp()
@@ -216,7 +207,6 @@ describe('the api of app', () => {
       expect(appy.vm).to.be.null
       expect(appy.doc).to.be.null
       expect(appy.customComponentMap).to.be.null
-      expect(appy.callbacks).to.be.null
     })
   })
 })

--- a/html5/test/unit/default/app/index.js
+++ b/html5/test/unit/default/app/index.js
@@ -6,7 +6,6 @@ chai.use(sinonChai)
 
 import App from '../../../../frameworks/legacy/app'
 import { Element, Document } from '../../../../runtime/vdom'
-import CallbackManager from '../../../../runtime/callback-manager'
 
 describe('App Instance', () => {
   const oriDocumentHandler = Document.handler
@@ -16,7 +15,7 @@ describe('App Instance', () => {
   beforeEach(() => {
     Document.handler = sendTasksSpy
     const id = Date.now() + ''
-    app = new App(id, {}, new CallbackManager(id))
+    app = new App(id, {})
   })
 
   afterEach(() => {
@@ -71,6 +70,8 @@ describe('App Instance', () => {
     })
 
     it('with function arg', (done) => {
+      const callbackId = '1'
+
       const tasks = [{
         module: 'dom',
         method: 'createBody',
@@ -78,8 +79,11 @@ describe('App Instance', () => {
       }]
 
       app.callTasks(tasks)
-      expect(sendTasksSpy.lastCall.args[1]).to.deep.equal(tasks)
-      expect(sendTasksSpy.lastCall.args[1][0].args[0]).to.be.a('string')
+      expect(sendTasksSpy.lastCall.args[1]).to.deep.equal([{
+        module: 'dom',
+        method: 'createBody',
+        args: [callbackId]
+      }])
       done()
     })
 
@@ -94,12 +98,17 @@ describe('App Instance', () => {
       }]
 
       app.callTasks(tasks)
-      expect(sendTasksSpy.lastCall.args[1]).to.deep.equal(tasks)
-      expect(sendTasksSpy.lastCall.args[1][0].args[0]).to.be.equal('1')
+      expect(sendTasksSpy.lastCall.args[1]).to.deep.equal([{
+        module: 'dom',
+        method: 'createBody',
+        args: [node.ref]
+      }])
       done()
     })
 
     it('with callback after close', (done) => {
+      const callbackId = '1'
+
       const tasks = [{
         module: 'dom',
         method: 'createBody',
@@ -109,8 +118,11 @@ describe('App Instance', () => {
       app.doc.close()
 
       app.callTasks(tasks)
-      expect(sendTasksSpy.lastCall.args[1]).to.deep.equal(tasks)
-      expect(sendTasksSpy.lastCall.args[1][0].args[0]).to.be.a('string')
+      expect(sendTasksSpy.lastCall.args[1]).to.deep.equal([{
+        module: 'dom',
+        method: 'createBody',
+        args: [callbackId]
+      }])
       done()
     })
   })


### PR DESCRIPTION
Move callbackManager to TaskCenter.
All callbacks from module & component are managed by TaskCenter.