### PR TITLE
[iOS] make loading main.js file safer

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -169,7 +169,7 @@
     WX_MONITOR_PERF_START(WXPTInitalize)
     WX_MONITOR_PERF_START(WXPTInitalizeSync)
     
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"main" ofType:@"js"];
+    NSString *filePath = [[NSBundle bundleForClass:self] pathForResource:@"main" ofType:@"js"];
     NSString *script = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
     [WXSDKEngine initSDKEnvironment:script];
     
@@ -260,7 +260,7 @@ static NSDictionary *_customEnvironment;
     NSDictionary *handlers = [WXHandlerFactory handlerConfigs];
     [WXSDKManager unload];
     [WXComponentFactory unregisterAllComponents];
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"main" ofType:@"js"];
+    NSString *filePath = [[NSBundle bundleForClass:self] pathForResource:@"main" ofType:@"js"];
     NSString *script = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
     
     [self _originalRegisterComponents:components];


### PR DESCRIPTION
通过 `use_frameworks!` 将 WeexSDK 以动态库形式引入项目后，对 `main.js` 的读取就不 work 了，因为 `main.js` 的路径变为了 `MyApp.app/Frameworks/MyFramework.framework/main.js`。

使用 `[NSBundle bundleForClass:self]` 可以始终正确地取出包含 `main.js` 的 bundle，不管它是 main bundle 还是什么。