### PR TITLE
fix unexpected keyboard hide when modify value of the <input> .

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -261,12 +261,15 @@ WX_EXPORT_METHOD(@selector(blur))
     _attr = attributes;
     if (attributes[@"type"]) {
         _inputType = [WXConvert NSString:attributes[@"type"]];
+        [self setType];
     }
-    [self setType];
-    _autofocus = [attributes[@"autofocus"] boolValue];
-    [self setAutofocus:_autofocus];
-    _disabled = [attributes[@"disabled"] boolValue];
-    [_inputView setEnabled:!_disabled];
+    if (attributes[@"autofocus"]) {
+        self.autofocus = [attributes[@"autofocus"] boolValue];
+    }
+    if (attributes[@"disabled"]) {
+        _disabled = [attributes[@"disabled"] boolValue];
+        [_inputView setEnabled:!_disabled];
+    }
     if (attributes[@"maxlength"]) {
         _maxLength = [NSNumber numberWithInteger:[attributes[@"maxlength"] integerValue]];
     }


### PR DESCRIPTION
修改 `<input>` 的 value 时，`updateAttributes` 方法调用了`setAutofocus`而导致 不需要的键盘隐藏。 所以做了一些修正。 