### PR TITLE
* [ios] fire loading & refresh event only once

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXLoadingComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXLoadingComponent.m
@@ -101,7 +101,7 @@
 
 - (void)loading
 {
-    if (!_loadingEvent)
+    if (!_loadingEvent || _displayState)
         return;
     
     [self fireEvent:@"loading" params:nil];

--- a/ios/sdk/WeexSDK/Sources/Component/WXRefreshComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXRefreshComponent.m
@@ -67,7 +67,7 @@
 
 - (void)refresh
 {
-    if (!_refreshEvent) {
+    if (!_refreshEvent || _displayState) {
         return;
     }
     [self fireEvent:@"refresh" params:nil];


### PR DESCRIPTION
之前是会一直 fire 事件，即使状态已经是`show`