### PR TITLE
+ [ios] add returnKeyType for textarea and input

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -446,13 +446,13 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         NSDictionary *contentSizeData = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithFloat:scrollView.contentSize.width / scaleFactor],@"width",[NSNumber numberWithFloat:scrollView.contentSize.height / scaleFactor],@"height", nil];
         //contentOffset values are replaced by (-contentOffset.x,-contentOffset.y) ,in order to be consistent with Android client.
         NSDictionary *contentOffsetData = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithFloat:-scrollView.contentOffset.x / scaleFactor],@"x",[NSNumber numberWithFloat:-scrollView.contentOffset.y / scaleFactor],@"y", nil];
-        float distance = 0;
+        CGFloat distance = 0;
         if (_scrollDirection == WXScrollDirectionHorizontal) {
             distance = scrollView.contentOffset.x - _lastScrollEventFiredOffset.x;
         } else {
             distance = scrollView.contentOffset.y - _lastScrollEventFiredOffset.y;
         }
-        if (fabsf(distance) >= _offsetAccuracy) {
+        if (fabs(distance) >= _offsetAccuracy) {
             [self fireEvent:@"scroll" params:@{@"contentSize":contentSizeData,@"contentOffset":contentOffsetData} domChanges:nil];
             _lastScrollEventFiredOffset = scrollView.contentOffset;
         }

--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
@@ -607,7 +607,7 @@
         CGFloat width = scrollView.frame.size.width;
         CGFloat XDeviation = scrollView.frame.origin.x - (scrollView.contentOffset.x - width);
         CGFloat offsetXRatio = (XDeviation / width);
-        if (fabsf(offsetXRatio - _lastOffsetXRatio) >= _offsetXAccuracy) {
+        if (fabs(offsetXRatio - _lastOffsetXRatio) >= _offsetXAccuracy) {
             _lastOffsetXRatio = offsetXRatio;
             [self fireEvent:@"scroll" params:@{@"offsetXRatio":[NSNumber numberWithFloat:offsetXRatio]} domChanges:nil];
         }
@@ -662,7 +662,7 @@
     CGFloat width = scrollView.frame.size.width;
     CGFloat XDeviation = scrollView.frame.origin.x - (scrollView.contentOffset.x - width);
     CGFloat offsetXRatio = (XDeviation / width);
-    if (fabsf(offsetXRatio) < 0.5) {
+    if (fabs(offsetXRatio) < 0.5) {
         [self sliderView:self.sliderView scrollViewDidCancelDraging:self.sliderView.scrollView];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -92,8 +92,8 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
                 _placeholderString = placeHolder;
             }
         }
-        if (attributes[@"returnkeytype"]) {
-            _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
+        if (attributes[@"returnKeyType"]) {
+            _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnKeyType"]];
         }
         if (!_placeholderString) {
             _placeholderString = @"";
@@ -307,8 +307,8 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
             }
         }
     }
-    if (attributes[@"returnkeytype"]) {
-        _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
+    if (attributes[@"returnKeyType"]) {
+        _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnKeyType"]];
         [_textView setReturnKeyType:_returnKeyType];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -28,6 +28,7 @@ typedef UITextView WXTextAreaView;
 @property (nonatomic) BOOL autofocus;
 @property (nonatomic) BOOL disabled;
 @property (nonatomic, strong)NSString *textValue;
+@property(nonatomic) UIReturnKeyType returnKeyType;
 @property (nonatomic) NSUInteger rows;
 //style
 
@@ -43,6 +44,7 @@ typedef UITextView WXTextAreaView;
 @property (nonatomic) BOOL focusEvent;
 @property (nonatomic) BOOL blurEvent;
 @property (nonatomic) BOOL changeEvent;
+@property (nonatomic) BOOL returnEvent;
 @property (nonatomic) BOOL clickEvent;
 @property (nonatomic, strong) NSString *changeEventString;
 @property (nonatomic, assign) CGSize keyboardSize;
@@ -69,6 +71,7 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         _blurEvent = NO;
         _changeEvent = NO;
         _clickEvent = NO;
+        _returnEvent = NO;
         _padding = UIEdgeInsetsZero;
         _border = UIEdgeInsetsZero;
         
@@ -88,6 +91,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
             if (placeHolder) {
                 _placeholderString = placeHolder;
             }
+        }
+        if (attributes[@"returnkeytype"]) {
+            _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
         }
         if (!_placeholderString) {
             _placeholderString = @"";
@@ -189,6 +195,7 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     _padding = UIEdgeInsetsZero;
     _border = UIEdgeInsetsZero;
     [self updatePattern];
+    [_textView setReturnKeyType:_returnKeyType];
     
     [_textView setNeedsDisplay];
     [_textView setClipsToBounds:YES];
@@ -248,6 +255,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     if ([eventName isEqualToString:@"click"]) {
         _clickEvent = YES;
     }
+    if ([eventName isEqualToString:@"return"]) {
+        _returnEvent = YES;
+    }
 }
 
 -(void)removeEvent:(NSString *)eventName
@@ -266,6 +276,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     }
     if ([eventName isEqualToString:@"click"]) {
         _clickEvent = NO;
+    }
+    if ([eventName isEqualToString:@"return"]) {
+        _returnEvent = NO;
     }
 }
 
@@ -293,6 +306,10 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
                 _placeHolderLabel.text = @"";
             }
         }
+    }
+    if (attributes[@"returnkeytype"]) {
+        _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
+        [_textView setReturnKeyType:_returnKeyType];
     }
 }
 
@@ -436,6 +453,17 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     if(self.pseudoClassStyles && [self.pseudoClassStyles count]>0){
         [self recoveryPseudoStyles:self.styles];
     }
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
+{
+    if ([text isEqualToString:@"\n"]) {
+        if (_returnEvent) {
+            NSString *typeStr = [WXUtility returnKeyType:_returnKeyType];
+            [self fireEvent:@"return" params:@{@"value":[textView text],@"returnKeyType":typeStr} domChanges:@{@"attrs":@{@"value":[textView text]}}];
+        }
+    }
+    return YES;
 }
 
 #pragma mark - private method

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -124,8 +124,8 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         if (attributes[@"maxlength"]) {
             _maxLength = [NSNumber numberWithUnsignedInteger:[attributes[@"maxlength"] integerValue]];
         }
-        if (attributes[@"returnkeytype"]) {
-            _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
+        if (attributes[@"returnKeyType"]) {
+            _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnKeyType"]];
         }
         
         // handle styles
@@ -316,8 +316,8 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         _value = [WXConvert NSString:attributes[@"value"]]?:@"";
         [_inputView setText:_value];
     }
-    if (attributes[@"returnkeytype"]) {
-        _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
+    if (attributes[@"returnKeyType"]) {
+        _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnKeyType"]];
         [_inputView setReturnKeyType:_returnKeyType];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -65,6 +65,7 @@
 @property (nonatomic) NSNumber *maxLength;
 @property (nonatomic) NSString * value;
 @property (nonatomic) BOOL autofocus;
+@property(nonatomic) UIReturnKeyType returnKeyType;
 @property (nonatomic) BOOL disabled;
 @property (nonatomic, copy) NSString *inputType;
 //style
@@ -80,6 +81,7 @@
 @property (nonatomic) BOOL focusEvent;
 @property (nonatomic) BOOL blurEvent;
 @property (nonatomic) BOOL changeEvent;
+@property (nonatomic) BOOL returnEvent;
 @property (nonatomic, strong) NSString *changeEventString;
 @property (nonatomic, assign) CGSize keyboardSize;
 
@@ -109,6 +111,7 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         _focusEvent = NO;
         _blurEvent = NO;
         _changeEvent = NO;
+        _returnEvent = NO;
         // handle attributes
         _autofocus = [attributes[@"autofocus"] boolValue];
         _disabled = [attributes[@"disabled"] boolValue];
@@ -120,6 +123,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         }
         if (attributes[@"maxlength"]) {
             _maxLength = [NSNumber numberWithUnsignedInteger:[attributes[@"maxlength"] integerValue]];
+        }
+        if (attributes[@"returnkeytype"]) {
+            _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
         }
         
         // handle styles
@@ -141,7 +147,6 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         if (styles[@"textAlign"]) {
             _textAlignForStyle = [WXConvert NSTextAlignment:styles[@"textAlign"]];
         }
-        
         if (styles[@"placeholderColor"]) {
             _placeholderColor = [WXConvert UIColor:styles[@"placeholderColor"]];
         }else {
@@ -178,6 +183,7 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     [_inputView setTextColor:_colorForStyle];
     [_inputView setText:_value];
     [_inputView setEnabled:!_disabled];
+    [_inputView setReturnKeyType:_returnKeyType];
     [self updatePattern];
     
     UIBarButtonItem *barButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(closeKeyboard)];
@@ -257,6 +263,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     if ([eventName isEqualToString:@"change"]) {
         _changeEvent = YES;
     }
+    if ([eventName isEqualToString:@"return"]) {
+        _returnEvent = YES;
+    }
 }
 
 #pragma Remove Event
@@ -274,6 +283,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     }
     if ([eventName isEqualToString:@"change"]) {
         _changeEvent = NO;
+    }
+    if ([eventName isEqualToString:@"return"]) {
+        _returnEvent = NO;
     }
 }
 
@@ -303,6 +315,10 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     if (attributes[@"value"]) {
         _value = [WXConvert NSString:attributes[@"value"]]?:@"";
         [_inputView setText:_value];
+    }
+    if (attributes[@"returnkeytype"]) {
+        _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnkeytype"]];
+        [_inputView setReturnKeyType:_returnKeyType];
     }
 }
 
@@ -448,6 +464,15 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     if(self.pseudoClassStyles && [self.pseudoClassStyles count]>0){
         [self recoveryPseudoStyles:self.styles];
     }
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField
+{
+    if (_returnEvent) {
+        NSString *typeStr = [WXUtility returnKeyType:_returnKeyType];
+         [self fireEvent:@"return" params:@{@"value":[textField text],@"returnKeyType":typeStr} domChanges:@{@"attrs":@{@"value":[textField text]}}];
+    }
+    return YES;
 }
 
 - (void)textFiledEditChanged:(NSNotification *)notifi

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
@@ -56,6 +56,7 @@ typedef BOOL WXClipType;
 + (CGFloat)WXTextWeight:(id)value;
 + (WXTextDecoration)WXTextDecoration:(id)value;
 + (NSTextAlignment)NSTextAlignment:(id)value;
++ (UIReturnKeyType)UIReturnKeyType:(id)value;
 
 + (WXScrollDirection)WXScrollDirection:(id)value;
 + (UITableViewRowAnimation)UITableViewRowAnimation:(id)value;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -469,6 +469,26 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
     return NSTextAlignmentNatural;
 }
 
++ (UIReturnKeyType)UIReturnKeyType:(id)value
+{
+    if([value isKindOfClass:[NSString class]]){
+        NSString *string = (NSString *)value;
+        if ([string isEqualToString:@"defalut"])
+            return UIReturnKeyDefault;
+        else if ([string isEqualToString:@"go"])
+            return UIReturnKeyGo;
+        else if ([string isEqualToString:@"next"])
+            return UIReturnKeyNext;
+        else if ([string isEqualToString:@"search"])
+            return UIReturnKeySearch;
+        else if ([string isEqualToString:@"send"])
+            return UIReturnKeySend;
+        else if ([string isEqualToString:@"done"])
+            return UIReturnKeyDone;
+    }
+    return UIReturnKeyDefault;
+}
+
 + (WXTextStyle)WXTextStyle:(id)value
 {
     if([value isKindOfClass:[NSString class]]){

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.h
@@ -388,4 +388,10 @@ BOOL WXFloatGreaterThan(CGFloat a, CGFloat b);
  */
 BOOL WXFloatGreaterThanWithPrecision(CGFloat a,CGFloat b,double precision);
 
+/**
+ *  @abstract convert returnKeyType to type string .
+ *
+ */
++ (NSString *_Nullable)returnKeyType:(UIReturnKeyType)type;
+
 @end

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -672,6 +672,55 @@ static BOOL WXNotStat;
     
 }
 
+BOOL WXFloatEqual(CGFloat a, CGFloat b) {
+    return WXFloatEqualWithPrecision(a, b,FLT_EPSILON);
+}
+BOOL WXFloatEqualWithPrecision(CGFloat a, CGFloat b ,double precision){
+    return fabs(a - b) <= precision;
+}
+BOOL WXFloatLessThan(CGFloat a, CGFloat b) {
+    return WXFloatLessThanWithPrecision(a, b, FLT_EPSILON);
+}
+BOOL WXFloatLessThanWithPrecision(CGFloat a, CGFloat b ,double precision){
+    return a-b < - precision;
+}
+
+BOOL WXFloatGreaterThan(CGFloat a, CGFloat b) {
+    return WXFloatGreaterThanWithPrecision(a, b, FLT_EPSILON);
+}
+BOOL WXFloatGreaterThanWithPrecision(CGFloat a, CGFloat b ,double precision){
+    return a-b > precision;
+}
+
++ (NSString *_Nullable)returnKeyType:(UIReturnKeyType)type
+{
+    NSString *typeStr = @"defalut";
+    switch (type) {
+        case UIReturnKeyDefault:
+            typeStr = @"defalut";
+            break;
+        case UIReturnKeyGo:
+            typeStr = @"go";
+            break;
+        case UIReturnKeyNext:
+            typeStr = @"next";
+            break;
+        case UIReturnKeySearch:
+            typeStr = @"search";
+            break;
+        case UIReturnKeySend:
+            typeStr = @"send";
+            break;
+        case UIReturnKeyDone:
+            typeStr = @"done";
+            break;
+            
+        default:
+            break;
+    }
+    return typeStr;
+}
+
 @end
 
 
@@ -702,22 +751,4 @@ CGPoint WXPixelPointResize(CGPoint value)
     return new;
 }
 
-BOOL WXFloatEqual(CGFloat a, CGFloat b) {
-    return WXFloatEqualWithPrecision(a, b,FLT_EPSILON);
-}
-BOOL WXFloatEqualWithPrecision(CGFloat a, CGFloat b ,double precision){
-    return fabs(a - b) <= precision;
-}
-BOOL WXFloatLessThan(CGFloat a, CGFloat b) {
-    return WXFloatLessThanWithPrecision(a, b, FLT_EPSILON);
-}
-BOOL WXFloatLessThanWithPrecision(CGFloat a, CGFloat b ,double precision){
-    return a-b < - precision;
-}
 
-BOOL WXFloatGreaterThan(CGFloat a, CGFloat b) {
-    return WXFloatGreaterThanWithPrecision(a, b, FLT_EPSILON);
-}
-BOOL WXFloatGreaterThanWithPrecision(CGFloat a, CGFloat b ,double precision){
-    return a-b > precision;
-}


### PR DESCRIPTION
+ [ios] add returnKeyType for textarea and input

## 需求
## 场景
- 比如input，如果用户点击了搜索按钮，自动提交表单

## 期望
- 能设置返回键类型，能返回数据

## 解决方案
- ios 和安卓设置统一返回键类型


## 类型
- 组件属性
- 支持input，textarea

## 名字
- 属性：returnKeyType
- 回调：onReturn
   - returnKeyType:返回键类型
   - value:本框内容

## 实现
- 类型
   - defalut;go;next;search;send,done



## dsl demo

```javascript
<template>
    <div>
        <div>
            <text style="font-size: 40px">oninput: {{txtInput}}</text>
            <text style="font-size: 40px">onchange: {{txtChange}}</text>
            <text style="font-size: 40px">onreturn: {{txtreturn}}</text>
        </div>
        <scroller>
            <wxc-panel title="input type = text" type="primary">
                <textarea
                        type="text"
                        placeholder="Input Text"
                        class="input"
                        autofocus="{{autofocus}}"
                        value=""
                        returnKeyType="done"
                        onchange="onchange"
                        oninput="oninput"
                        onreturn = "onreturn"
                ></textarea>
            </wxc-panel>

            
        </scroller>
    </div>
</template>

<style>
    .input {
        font-size: 60px;
        height: 80px;
        width: 750px;
    }
</style>

<script>
    require('weex-components');
    module.exports = {
        data: {
            txtInput: '',
            txtChange: '',
            autofocus: false,
            txtreturn:''
        },
        methods: {
            ready : function () {
                var self = this;
                setTimeout(function () {
                    self.autofocus = true;
                },1000);
            },
            onchange: function (event) {
                this.txtChange = event.value;
                console.log('onchange', event.value);
            },
            oninput: function (event) {
                this.txtInput = event.value;
                console.log('oninput', event.value);
            },
            onreturn: function (event) {
                this.txtreturn = event.returnKeyType;
                console.log('onreturn', event.type);
            },
            focus: function () {
                this.$el('input1').focus();
            },
            blur: function () {
                this.$el('input1').blur();
            }
        }
    };
</script>

```
