### PR TITLE
* [ios] fix bug: user custom handlers are reset to defaults

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -174,9 +174,6 @@ typedef enum : NSUInteger {
         }
     });
     
-    // ensure default modules/components/handlers are ready before create instance
-    [WXSDKEngine registerDefaults];
-    
     [[WXSDKManager bridgeMgr] createInstance:self.instanceId template:mainBundleString options:dictionary data:_jsData];
     
     WX_MONITOR_PERF_SET(WXPTBundleSize, [mainBundleString lengthOfBytesUsingEncoding:NSUTF8StringEncoding], self);


### PR DESCRIPTION
sdk engine的初始化操作不应该在这里。
在 instance里的初始化会导致用户在 sdk engine注册的 handlers 被覆盖。