### PR TITLE
* [ios] fix refresh, loading component content inset

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXLoadingComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXLoadingComponent.m
@@ -114,13 +114,17 @@
         return;
     WXComponent *scroller = (WXComponent*)scrollerProtocol;
     CGPoint contentOffset = [scrollerProtocol contentOffset];
+    UIEdgeInsets inset = [scrollerProtocol contentInset];
     if (_displayState) {
         contentOffset.y = [scrollerProtocol contentSize].height - scroller.calculatedFrame.size.height + self.calculatedFrame.size.height;
+        inset.bottom = CGRectGetHeight(self.calculatedFrame);
         [_indicator start];
     } else {
         contentOffset.y = contentOffset.y - self.calculatedFrame.size.height;
+        inset.bottom = 0;
         [_indicator stop];
     }
+    [scrollerProtocol setContentInset:inset];
     [scrollerProtocol setContentOffset:contentOffset animated:YES];
 }
 

--- a/ios/sdk/WeexSDK/Sources/Component/WXRefreshComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXRefreshComponent.m
@@ -133,13 +133,17 @@
         return;
     
     CGPoint offset = [scrollerProtocol contentOffset];
+    UIEdgeInsets inset = [scrollerProtocol contentInset];
     if (_displayState) {
         offset.y = -self.calculatedFrame.size.height;
+        inset.top = CGRectGetHeight(self.calculatedFrame);
         [_indicator start];
     } else {
         offset.y = 0;
+        inset.top = 0;
         [_indicator stop];
     }
+    [scrollerProtocol setContentInset:inset];
     [scrollerProtocol setContentOffset:offset animated:YES];
 }
 

--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -459,24 +459,6 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     }
 }
 
-- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
-{
-    UIEdgeInsets inset = [scrollView contentInset];
-    if ([_refreshComponent displayState]) {
-        inset.top = _refreshComponent.view.frame.size.height;
-    }
-    else {
-        inset.top = 0;
-    }
-    if ([_loadingComponent displayState]) {
-        inset.bottom = _loadingComponent.view.frame.size.height;
-    } else {
-        inset.bottom = 0;
-    }
-    
-    [scrollView setContentInset:inset];
-}
-
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
     [_loadingComponent.view setHidden:NO];


### PR DESCRIPTION
界面刷新很快的时候，某些情况下 content inset 不会更新。比如 修改后的 content offet 和修改前的 content offset 一样时。
所以更新 content inset 的事还是交给对应的 component 更合理，毕竟 content offset 也是在此更新的。