### PR TITLE
[ios] update the podspec file

### DIFF
--- a/ios/sdk/WeexSDK.podspec
+++ b/ios/sdk/WeexSDK.podspec
@@ -29,18 +29,8 @@ Pod::Spec.new do |s|
   s.source =  { :path => '.' }
   s.source_files = 'WeexSDK/Sources/**/*.{h,m,mm,c}'
   s.resources = 'WeexSDK/Resources/main.js', 'WeexSDK/Resources/wx_load_error@3x.png'
-
-  s.requires_arc = true
   s.prefix_header_file = 'WeexSDK/Sources/Supporting Files/WeexSDK-Prefix.pch'
-
-#  s.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => '$(inherited) DEBUG=1' }
-
-  s.xcconfig = { "OTHER_LINK_FLAG" => '$(inherited) -ObjC'}
-
-  s.user_target_xcconfig  = { 'FRAMEWORK_SEARCH_PATHS' => "'$(PODS_ROOT)/WeexSDK'" }
-
   s.frameworks = 'CoreMedia','MediaPlayer','AVFoundation','AVKit','JavaScriptCore', 'GLKit'
-
   s.dependency 'SocketRocket'
   s.libraries = "stdc++"
 


### PR DESCRIPTION
Update the `podspec` file , removing the useless code. 

In Pod , the `ARC` is opened by default. The `-ObjC` link flag is set up by default. In source mode, using the `FRAMEWORK_SEARCH_PATHS` would cause some compilation error which the Xcode would not exactly find head files.

I advice that `weex` should creat two subspecs or two pod libraries. One library is in source. One library use compiled framework. A library in source is more important than easy installation in China . We should enjoy the convenience of CocoaPods. 

## 中文

`FRAMEWORK_SEARCH_PATHS` 只应该用于 `framework` 的head查找。 在源码模式时，会导致Header查找失败而编译失败（当在项目中引入weex中的一些头文件时，就会报错）

还有一个建议， 建议你们发布一个源码的 pod ,而不是只有一个编译后的framework 的pod , 这个对于开发者更为重要，因为使用你们的`framework`，没了源码，开发者看不清你们的逻辑，也没法调试，没法帮你们找BUG了。源码的依赖库，极其重要，希望你们尽快提供一个。