### PR TITLE
* [ios] change initSDKEnvironment monitor location

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -167,14 +167,10 @@
 
 + (void)initSDKEnvironment
 {
-    WX_MONITOR_PERF_START(WXPTInitalize)
-    WX_MONITOR_PERF_START(WXPTInitalizeSync)
     
     NSString *filePath = [[NSBundle bundleForClass:self] pathForResource:@"main" ofType:@"js"];
     NSString *script = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
     [WXSDKEngine initSDKEnvironment:script];
-    
-    WX_MONITOR_PERF_END(WXPTInitalizeSync)
     
 #if TARGET_OS_SIMULATOR
     static dispatch_once_t onceToken;
@@ -204,6 +200,10 @@
 
 + (void)initSDKEnvironment:(NSString *)script
 {
+    
+    WX_MONITOR_PERF_START(WXPTInitalize)
+    WX_MONITOR_PERF_START(WXPTInitalizeSync)
+    
     if (!script || script.length <= 0) {
         WX_MONITOR_FAIL(WXMTJSFramework, WX_ERR_JSFRAMEWORK_LOAD, @"framework loading is failure!");
         return;
@@ -213,6 +213,9 @@
         [self registerDefaults];
         [[WXSDKManager bridgeMgr] executeJsFramework:script];
     });
+    
+    WX_MONITOR_PERF_END(WXPTInitalizeSync)
+    
 }
 
 + (void)registerDefaults


### PR DESCRIPTION
真正初始化 sdk 是在initSDKEnvironment： 函数中，这个函数是public 属性的，加载这个位置感觉上更合理(init SDK Environment execute in fuction initSDKEnvironment:, this function is public function
 it is reasonable to add monitor in the location of fuction initSDKEnvironment: )