### PR TITLE
* [android] Fix linear-gradien problem

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/border/BorderDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/border/BorderDrawable.java
@@ -455,6 +455,10 @@ public class BorderDrawable extends Drawable {
     invalidateSelf();
   }
 
+  public boolean hasImage(){
+    return mShader!=null;
+  }
+
   public boolean isRounded() {
     return mBorderRadius != null &&
            (!FloatUtil.floatsEqual(getBorderRadius(mBorderRadius, BORDER_TOP_LEFT_RADIUS), 0) ||


### PR DESCRIPTION
Fix linear-gradient & border-radius & clipPath cannot work together if system version is 4.3 or 4.4.

Without this fix, the [border-radius of linear-gradient div](http://dotwe.org/weex/963c9ade129f86757cecdd85651cd30e) will not work.

This is mostly likely due to OpenGL ES 3.1, which provided  "Separate shader objects" is not supported until android 5.0.