### PR TITLE
* [iOS] model WXSDKInstance update _options property

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -187,7 +187,6 @@ typedef enum : NSUInteger {
 {
     NSURL *url = request.URL;
     _scriptURL = url;
-    _options = options;
     _jsData = data;
     NSMutableDictionary *newOptions = [options mutableCopy] ?: [NSMutableDictionary new];
     
@@ -199,7 +198,8 @@ typedef enum : NSUInteger {
         WXLogWarning(@"Error type in options with key:bundleUrl, should be of type NSString, not NSURL!");
         newOptions[bundleUrlOptionKey] = ((NSURL*)newOptions[bundleUrlOptionKey]).absoluteString;
     }
-    
+    _options = [newOptions copy];
+  
     if (!self.pageName || [self.pageName isEqualToString:@""]) {
         self.pageName = [WXUtility urlByDeletingParameters:url].absoluteString ? : @"";
     }


### PR DESCRIPTION
-[WXSDKInstance_renderWithRequest:options:data:  ]这个方法里我注意到有写 options中 bundleUrl类型的兼容方案，但是 newOptions 这个处理后没有用到，是我理解有误还是其它问题。
