### PR TITLE
* [ios] fixbug when active ,the border-radius  lose efficacy

### DIFF
--- a/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.m
+++ b/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.m
@@ -118,7 +118,6 @@
     
     if (styles[@"backgroundColor"]) {
         _backgroundColor = [WXConvert UIColor:styles[@"backgroundColor"]];
-        _layer.backgroundColor = _backgroundColor.CGColor;
         [self setNeedsDisplay];
     }
     
@@ -186,7 +185,6 @@
 {
     if (styles && [styles containsObject:@"backgroundColor"]) {
         _backgroundColor = [UIColor clearColor];
-        _layer.backgroundColor = _backgroundColor.CGColor;
         [self setNeedsDisplay];
     }
     if (styles && [styles containsObject:@"boxShadow"]) {


### PR DESCRIPTION
## 更改方案
- 删除代码_layer.backgroundColor = _backgroundColor.CGColor，之前加上是为了避免cell不能从更新总恢复，现在这个代码已经在WXComponent+Display.m文件中执行了 (delete the code _layer.backgroundColor = _backgroundColor.CGColor; because it execute WXComponent+Display)

## 测试用例
- 伪类 http://dotwe.org/weex/d763a062ec89ec82469783d07c7f477f
- 更新 http://dotwe.org/weex/6b6e4b8ddb8156a2deea703c0ad64f1a