### PR TITLE
* [Android] Fix 1px border radius

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/border/BorderDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/border/BorderDrawable.java
@@ -633,7 +633,6 @@ public class BorderDrawable extends Drawable {
     Shader shader = borderStyle.getLineShader(borderWidth, color, side);
     mPaint.setShader(shader);
     mPaint.setColor(color);
-    mPaint.setStrokeWidth(borderWidth);
     mPaint.setStrokeCap(Paint.Cap.ROUND);
   }
 }


### PR DESCRIPTION
Due to hardware-acceleration & 750px viewport & sub-pixel, border-radius of [some page](http://dotwe.org/weex/421b9ad09fde51c0b49bb56b37fcf955) will not be rendered. 

This commit try to fix the problem, using `Canvas.drawArc` instead of `Path.addArc` to skip hardware-acceleration behavior.