### PR TITLE
[html5] bugfix image

### DIFF
--- a/examples/vue/animation.vue
+++ b/examples/vue/animation.vue
@@ -130,7 +130,7 @@
   };
 </script>
 
-<style>
+<style scoped>
   .block {
     position: absolute;
     width: 250px;

--- a/examples/vue/components/countdown.vue
+++ b/examples/vue/components/countdown.vue
@@ -27,7 +27,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .ctno1 {
     border-radius: 8;
     padding-top: 6;

--- a/examples/vue/components/image.vue
+++ b/examples/vue/components/image.vue
@@ -36,7 +36,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .img {
     margin-bottom: 20px;
   }

--- a/examples/vue/components/input.vue
+++ b/examples/vue/components/input.vue
@@ -16,7 +16,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .input {
     font-size: 60px;
     height: 80px;

--- a/examples/vue/components/list.vue
+++ b/examples/vue/components/list.vue
@@ -17,7 +17,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .list {
     height:850px
   }

--- a/examples/vue/components/scroller.vue
+++ b/examples/vue/components/scroller.vue
@@ -14,7 +14,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .refresh-view {
     height: 120px;
     width: 750px;

--- a/examples/vue/components/slider.vue
+++ b/examples/vue/components/slider.vue
@@ -57,7 +57,7 @@
         <slider class="slider" append="tree"
           :interval="sliders[2].interval"
           :autoPlay="sliders[2].autoPlay">
-          <indicator class="indicator" style="itemSelectedColor:rgb(217, 83, 79);"></indicator>
+          <indicator class="indicator" style="item-selected-color:rgb(217, 83, 79);"></indicator>
           <slider-page v-for="v in sliders[2].sliderPages" :items="v.items"></slider-page>
         </slider>
       </panel>
@@ -65,7 +65,7 @@
         <slider class="slider" append="tree"
           :interval="sliders[1].interval"
           :autoPlay="sliders[1].autoPlay">
-          <indicator style="itemColor: #dddddd;itemSize:40px;top:140px;left:180px;width:700px;height:380px;"></indicator>
+          <indicator style="itemColor: #dddddd;item-size:40px;top:140px;left:180px;width:700px;height:380px;"></indicator>
           <slider-page v-for="v in sliders[1].sliderPages" :items="v.items"></slider-page>
         </slider>
       </panel>
@@ -239,7 +239,7 @@
   };
 </script>
 
-<style>
+<style scoped>
   .body {
     background-color: #ffffff;
   }

--- a/examples/vue/components/text.vue
+++ b/examples/vue/components/text.vue
@@ -44,7 +44,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .txt {
     margin-bottom: 12px;
     font-size: 40px;

--- a/examples/vue/components/video.vue
+++ b/examples/vue/components/video.vue
@@ -11,7 +11,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .video {
     width: 750px;
     height: 460px;

--- a/examples/vue/components/web.vue
+++ b/examples/vue/components/web.vue
@@ -16,7 +16,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {
     width: 750;
     position: absolute;

--- a/examples/vue/iconfont.vue
+++ b/examples/vue/iconfont.vue
@@ -7,7 +7,7 @@
   </div>
 
 </template>
-<style>
+<style scoped>
   .title1 {
     color: red;
     font-size: 36;

--- a/examples/vue/include/button.vue
+++ b/examples/vue/include/button.vue
@@ -15,7 +15,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .btn {
     margin-bottom: 0;
     align-items: center;

--- a/examples/vue/include/countdown.vue
+++ b/examples/vue/include/countdown.vue
@@ -6,7 +6,7 @@
 </div>
 </template>
 
-<style>
+<style scoped>
 .wrap {
   overflow: hidden;
 }

--- a/examples/vue/include/example-list-item.vue
+++ b/examples/vue/include/example-list-item.vue
@@ -4,7 +4,7 @@
   </list-item>
 </template>
 
-<style>
+<style scoped>
   .item-txt {
     font-size: 48px;
     color: #555;

--- a/examples/vue/include/h1.vue
+++ b/examples/vue/include/h1.vue
@@ -2,7 +2,7 @@
   <text class="h1">{{value}}</text>
 </template>
 
-<style>
+<style scoped>
   .h1 {font-size: 64px; font-weight: bold;
     padding: 20px; margin-top: 20px; margin-bottom: 20px;
     background-color: #eee;}

--- a/examples/vue/include/h2.vue
+++ b/examples/vue/include/h2.vue
@@ -2,7 +2,7 @@
   <text class="h2">{{value}}</text>
 </template>
 
-<style>
+<style scoped>
   .h2 {font-size: 48px; font-weight: bold;
     padding: 20px; margin-top: 20px; margin-bottom: 20px;
     background-color: #eee;}

--- a/examples/vue/include/h3.vue
+++ b/examples/vue/include/h3.vue
@@ -2,7 +2,7 @@
   <text class="h3">{{value}}</text>
 </template>
 
-<style>
+<style scoped>
   .h3 {font-size: 36px; font-weight: bold;
     padding: 20px; margin-top: 20px; margin-bottom: 20px;
     background-color: #eee;}

--- a/examples/vue/include/hn.vue
+++ b/examples/vue/include/hn.vue
@@ -13,7 +13,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .h1 {
     height: 110px;
     padding-top: 20px;

--- a/examples/vue/include/list-item.vue
+++ b/examples/vue/include/list-item.vue
@@ -31,7 +31,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .item {
     padding-top: 25px;
     padding-bottom: 25px;

--- a/examples/vue/include/marquee.vue
+++ b/examples/vue/include/marquee.vue
@@ -11,7 +11,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrap {
     overflow: hidden;
     position: relative;

--- a/examples/vue/include/navbar.vue
+++ b/examples/vue/include/navbar.vue
@@ -34,7 +34,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .container {
     flex-direction: row; 
     position: fixed; 

--- a/examples/vue/include/navpage.vue
+++ b/examples/vue/include/navpage.vue
@@ -21,7 +21,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {
     position: absolute; 
     top: 0; 

--- a/examples/vue/include/panel.vue
+++ b/examples/vue/include/panel.vue
@@ -37,7 +37,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .panel {
     margin-bottom: 20px;
     background-color: #fff;

--- a/examples/vue/include/slider-item.vue
+++ b/examples/vue/include/slider-item.vue
@@ -11,7 +11,7 @@
   };
 </script>
 
-<style>
+<style scoped>
   .slider-item {
     width: 348px;
     height: 400px;

--- a/examples/vue/include/slider-page.vue
+++ b/examples/vue/include/slider-page.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .slider-page {
     flex-direction: row;
     justify-content: space-between;

--- a/examples/vue/include/tabbar.vue
+++ b/examples/vue/include/tabbar.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {
     width: 750;
     position: absolute;

--- a/examples/vue/include/tabitem.vue
+++ b/examples/vue/include/tabitem.vue
@@ -15,7 +15,7 @@
   </div>  
 </template>
 
-<style>
+<style scoped>
   .container {
     flex: 1; 
     flex-direction: column; 

--- a/examples/vue/include/tip.vue
+++ b/examples/vue/include/tip.vue
@@ -14,7 +14,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .tip {
     padding-left: 36px;
     padding-right: 36px;

--- a/examples/vue/include/wxc-list-item.vue
+++ b/examples/vue/include/wxc-list-item.vue
@@ -32,7 +32,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .item {
     padding-top: 25px;
     padding-bottom: 25px;

--- a/examples/vue/showcase/calculator.vue
+++ b/examples/vue/showcase/calculator.vue
@@ -28,7 +28,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .row {
     flex-direction: row;
   }

--- a/examples/vue/showcase/include/brand.vue
+++ b/examples/vue/showcase/include/brand.vue
@@ -6,7 +6,7 @@
     </div>
   </div>
 </template>
-<style>
+<style scoped>
   .title {
     width: 750;
     height: 100;

--- a/examples/vue/showcase/include/category.vue
+++ b/examples/vue/showcase/include/category.vue
@@ -32,7 +32,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {
     width: 750;
     height: 100;

--- a/examples/vue/showcase/include/coupon.vue
+++ b/examples/vue/showcase/include/coupon.vue
@@ -10,7 +10,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title{
     width:750;
     height:100;

--- a/examples/vue/showcase/include/goods.vue
+++ b/examples/vue/showcase/include/goods.vue
@@ -21,7 +21,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {
     width: 750;
     height: 100;

--- a/examples/vue/showcase/include/headlines.vue
+++ b/examples/vue/showcase/include/headlines.vue
@@ -15,7 +15,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .banner {
     width: 750;
     height: 782;

--- a/examples/vue/showcase/include/match.vue
+++ b/examples/vue/showcase/include/match.vue
@@ -15,7 +15,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {
     width: 750;
     height: 100;

--- a/examples/vue/showcase/include/resource.vue
+++ b/examples/vue/showcase/include/resource.vue
@@ -7,7 +7,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {
     width: 750;
     height: 100;

--- a/examples/vue/showcase/include/scene.vue
+++ b/examples/vue/showcase/include/scene.vue
@@ -17,7 +17,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {
     width: 750;
     height: 100;

--- a/examples/vue/showcase/itemlist.vue
+++ b/examples/vue/showcase/itemlist.vue
@@ -136,7 +136,7 @@
   </list>
 </template>
 
-<style>
+<style scoped>
   .flexRow {
     flex-direction: row;
   }

--- a/examples/vue/showcase/new-fashion.vue
+++ b/examples/vue/showcase/new-fashion.vue
@@ -19,7 +19,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .content {
     color: #353535;
     background-color: #666;

--- a/examples/vue/style/index.vue
+++ b/examples/vue/style/index.vue
@@ -22,7 +22,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .bg-item {
     width: 690px;
     margin-bottom: 10px;

--- a/examples/vue/style/style-box.vue
+++ b/examples/vue/style/style-box.vue
@@ -40,7 +40,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .box {
     background-color: #f5f5f5;
     width: 260px;

--- a/examples/vue/style/style-flex.vue
+++ b/examples/vue/style/style-flex.vue
@@ -101,7 +101,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .row {
     flex-direction: row;
     margin-bottom: 10px;

--- a/examples/vue/style/style-item.vue
+++ b/examples/vue/style/style-item.vue
@@ -19,7 +19,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .item {
     margin-right: 10px;
     /*margin-bottom: 10px;*/

--- a/examples/vue/syntax/hello-world-3.vue
+++ b/examples/vue/syntax/hello-world-3.vue
@@ -1,7 +1,7 @@
 <!--
   * <template>: html-like syntax
   * CSS-like inline style
-  * <style>: only support single-class selector
+  * <style scoped>: only support single-class selector
 -->
 
 <template>
@@ -14,7 +14,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {align-items: center; margin-top: 120px;}
   .title {font-size: 48px;}
   .logo {width: 360px; height: 82px;}

--- a/examples/vue/syntax/hello-world-4.vue
+++ b/examples/vue/syntax/hello-world-4.vue
@@ -1,7 +1,7 @@
 <!--
   * <template>: html-like syntax
   * CSS-like inline style
-  * <style>: only support single-class selector
+  * <style scoped>: only support single-class selector
   * <script>: define the behavior of component
   * :attr data-binding support
 -->
@@ -16,7 +16,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {align-items: center; margin-top: 120px;}
   .title {font-size: 48px;}
   .logo {width: 360px; height: 82px;}

--- a/examples/vue/syntax/hello-world-5.vue
+++ b/examples/vue/syntax/hello-world-5.vue
@@ -1,7 +1,7 @@
 <!--
   * <template>: html-like syntax
   * CSS-like inline style
-  * <style>: only support single-class selector
+  * <style scoped>: only support single-class selector
   * <script>: define the behavior of component
   * :attr data-binding support
   * @xxx syntax to bind event with a component method
@@ -14,7 +14,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {align-items: center; margin-top: 120px;}
   .title {font-size: 48px;}
   .logo {width: 360px; height: 82px;}

--- a/examples/vue/syntax/hello-world.vue
+++ b/examples/vue/syntax/hello-world.vue
@@ -1,7 +1,7 @@
 <!--
   * <template>: html-like syntax
   * CSS-like inline style
-  * <style>: only support single-class selector
+  * <style scoped>: only support single-class selector
   * <script>: define the behavior of component
   * :attr data-binding support
   * @xxx syntax to bind event with a component method
@@ -23,7 +23,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .wrapper {align-items: center; margin-top: 120px;}
   .title {font-size: 48px;}
   .logo {width: 360px; height: 82px;}

--- a/examples/vue/syntax/include/btn.vue
+++ b/examples/vue/syntax/include/btn.vue
@@ -4,6 +4,6 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .btn {font-size: 36px; text-align: center; color: white; background-color: gray; padding: 20px; border-radius: 5px;}
 </style>

--- a/examples/vue/syntax/include/sub.vue
+++ b/examples/vue/syntax/include/sub.vue
@@ -2,7 +2,7 @@
   <text class="item-txt">{{title}}</text>
 </template>
 
-<style>
+<style scoped>
   .item-txt {
     font-size: 48px;
     color: #555;

--- a/examples/vue/syntax/script-data.vue
+++ b/examples/vue/syntax/script-data.vue
@@ -18,7 +18,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
 </style>
 

--- a/examples/vue/syntax/script-events.vue
+++ b/examples/vue/syntax/script-events.vue
@@ -10,7 +10,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
 </style>
 

--- a/examples/vue/syntax/script-instance.vue
+++ b/examples/vue/syntax/script-instance.vue
@@ -15,7 +15,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
 </style>
 

--- a/examples/vue/syntax/script-lifecycle.vue
+++ b/examples/vue/syntax/script-lifecycle.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
 </style>
 

--- a/examples/vue/syntax/script-module.vue
+++ b/examples/vue/syntax/script-module.vue
@@ -9,7 +9,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .btn {font-size: 36px; text-align: center; color: white; background-color: gray; padding: 20px; border-radius: 5px;}
 </style>
 

--- a/examples/vue/syntax/script-options.vue
+++ b/examples/vue/syntax/script-options.vue
@@ -14,7 +14,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
 </style>
 

--- a/examples/vue/syntax/template-class.vue
+++ b/examples/vue/syntax/template-class.vue
@@ -10,7 +10,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .a {font-size: 48px;}
   .b {color: #ff0000;}
 </style>

--- a/examples/vue/syntax/template-event.vue
+++ b/examples/vue/syntax/template-event.vue
@@ -12,7 +12,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
   .subtitle {font-size: 36px;}
   .btn {font-size: 36px; text-align: center; color: white; background-color: gray; padding: 20px; border-radius: 5px;}

--- a/examples/vue/syntax/template-if.vue
+++ b/examples/vue/syntax/template-if.vue
@@ -10,7 +10,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
   .btn {font-size: 36px; text-align: center; color: white; background-color: gray; padding: 20px; border-radius: 5px;}
 </style>

--- a/examples/vue/syntax/template-repeat-update.vue
+++ b/examples/vue/syntax/template-repeat-update.vue
@@ -13,7 +13,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
   .subtitle {font-size: 36px;}
   .btn {font-size: 36px; text-align: center; color: white; background-color: gray; padding: 20px; border-radius: 5px;}

--- a/examples/vue/syntax/template-repeat.vue
+++ b/examples/vue/syntax/template-repeat.vue
@@ -14,7 +14,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .title {font-size: 48px;}
   .subtitle {font-size: 36px;}
 </style>

--- a/html5/render/vue/components/a.js
+++ b/html5/render/vue/components/a.js
@@ -9,14 +9,15 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('a', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('html:a', {
       attrs: {
         'weex-type': 'a',
         href: this.href
       },
       on: this._createEventMap(),
-      staticClass: 'weex-a'
+      staticClass: 'weex-a',
+      staticStyle: ms
     }, this.$slots.default)
   }
 }

--- a/html5/render/vue/components/div.js
+++ b/html5/render/vue/components/div.js
@@ -13,10 +13,12 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('div', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('html:div', {
       attrs: { 'weex-type': 'div' },
       on: this._createEventMap(),
-      staticClass: 'weex-div'
+      staticClass: 'weex-div',
+      staticStyle: ms
     }, trimTextNode(this.$slots.default))
   }
 }

--- a/html5/render/vue/components/div.js
+++ b/html5/render/vue/components/div.js
@@ -13,7 +13,6 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('div', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
     return createElement('html:div', {
       attrs: { 'weex-type': 'div' },
       on: this._createEventMap(),

--- a/html5/render/vue/components/image.js
+++ b/html5/render/vue/components/image.js
@@ -12,7 +12,13 @@ function getResizeStyle (context) {
 }
 
 function preProcessSrc (context, url) {
-  const { width, height } = context.$vnode.data.staticStyle
+  const staticStyle = context.$vnode.data.staticStyle
+  // somehow the merged style in _prerender hook is gone.
+  // just return the original src.
+  if (!staticStyle || !staticStyle.width || !staticStyle.height) {
+    return url
+  }
+  const { width, height } = staticStyle
   return context.processImgSrc && context.processImgSrc(url, {
     width: parseFloat(width),
     height: parseFloat(height),
@@ -24,19 +30,9 @@ function preProcessSrc (context, url) {
 
 export default {
   props: {
-    src: {
-      type: String,
-      required: true
-    },
-    placeholder: {
-      type: String
-    },
-    resize: {
-      validator (value) {
-        /* istanbul ignore next */
-        return ['cover', 'contain', 'stretch'].indexOf(value) !== -1
-      }
-    },
+    src: String,
+    placeholder: String,
+    resize: String,
     quality: String,
     sharpen: String,
     original: [String, Boolean]
@@ -62,6 +58,7 @@ export default {
     // cssText += (this.resize && this.resize !== 'stretch')
     //   ? `background-size: ${this.resize};`
     //   : `background-size: 100% 100%;`
+
     return createElement('figure', {
       attrs: {
         'weex-type': 'image',

--- a/html5/render/vue/components/image.js
+++ b/html5/render/vue/components/image.js
@@ -42,6 +42,10 @@ export default {
     original: [String, Boolean]
   },
 
+  updated () {
+    this._fireLazyload()
+  },
+
   mounted () {
     this._fireLazyload()
   },

--- a/html5/render/vue/components/image.js
+++ b/html5/render/vue/components/image.js
@@ -1,7 +1,7 @@
 import { extend, throttle } from '../utils'
 // import { validateStyles } from '../validator'
 
-const lazyloadAwait = 25  // milliseconds.
+const lazyloadAwait = 16  // milliseconds.
 let throttleLazyload
 function getThrottleLazyload (context, wait) {
   if (!throttleLazyload) {

--- a/html5/render/vue/components/image.js
+++ b/html5/render/vue/components/image.js
@@ -1,5 +1,14 @@
-import { extend } from '../utils'
+import { extend, throttle } from '../utils'
 // import { validateStyles } from '../validator'
+
+const lazyloadAwait = 25  // milliseconds.
+let throttleLazyload
+function getThrottleLazyload (context, wait) {
+  if (!throttleLazyload) {
+    throttleLazyload = throttle(context._fireLazyload, wait)
+  }
+  return throttleLazyload
+}
 
 /**
  * get resize (stetch|cover|contain) related styles.
@@ -11,14 +20,13 @@ function getResizeStyle (context) {
   return { 'background-size': bgSize }
 }
 
-function preProcessSrc (context, url) {
-  const staticStyle = context.$vnode.data.staticStyle
+function preProcessSrc (context, url, mergedStyle) {
   // somehow the merged style in _prerender hook is gone.
   // just return the original src.
-  if (!staticStyle || !staticStyle.width || !staticStyle.height) {
+  if (!mergedStyle || !mergedStyle.width || !mergedStyle.height) {
     return url
   }
-  const { width, height } = staticStyle
+  const { width, height } = mergedStyle
   return context.processImgSrc && context.processImgSrc(url, {
     width: parseFloat(width),
     height: parseFloat(height),
@@ -39,11 +47,11 @@ export default {
   },
 
   updated () {
-    this._fireLazyload()
+    getThrottleLazyload(this, lazyloadAwait)()
   },
 
   mounted () {
-    this._fireLazyload()
+    getThrottleLazyload(this, lazyloadAwait)()
   },
 
   render (createElement) {
@@ -58,21 +66,17 @@ export default {
     // cssText += (this.resize && this.resize !== 'stretch')
     //   ? `background-size: ${this.resize};`
     //   : `background-size: 100% 100%;`
+    const ms = this._getComponentStyle(this.$vnode.data)
 
     return createElement('figure', {
       attrs: {
         'weex-type': 'image',
-        'img-src': preProcessSrc(this, this.src),
-        'img-placeholder': preProcessSrc(this, this.placeholder)
+        'img-src': preProcessSrc(this, this.src, ms),
+        'img-placeholder': preProcessSrc(this, this.placeholder, ms)
       },
       on: this._createEventMap(['load', 'error']),
-      staticClass: 'weex-image'
+      staticClass: 'weex-image',
+      staticStyle: extend(ms, getResizeStyle(this))
     })
-  },
-
-  methods: {
-    beforeRender () {
-      extend(this.$options._parentVnode.data.staticStyle, getResizeStyle(this))
-    }
   }
 }

--- a/html5/render/vue/components/input.js
+++ b/html5/render/vue/components/input.js
@@ -33,7 +33,7 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('input', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('html:input', {
       attrs: {
         'weex-type': 'input',
@@ -45,7 +45,8 @@ export default {
         maxlength: this.maxlength
       },
       on: extend(this._createEventMap(), mapFormEvents(this)),
-      staticClass: 'weex-input'
+      staticClass: 'weex-input',
+      staticStyle: ms
     })
   }
 }

--- a/html5/render/vue/components/scrollable/header.js
+++ b/html5/render/vue/components/scrollable/header.js
@@ -46,13 +46,14 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('header', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('html:header', {
       attrs: { 'weex-type': 'header' },
       on: this._createEventMap(),
       ref: 'header',
       staticClass: 'weex-header',
-      class: { sticky: this.sticky, iossticky: this.supportSticky }
+      class: { sticky: this.sticky, iossticky: this.supportSticky },
+      staticStyle: ms
     }, this.$slots.default)
   }
 }

--- a/html5/render/vue/components/scrollable/list/cell.js
+++ b/html5/render/vue/components/scrollable/list/cell.js
@@ -6,11 +6,12 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('cell', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('section', {
       attrs: { 'weex-type': 'cell' },
       on: this._createEventMap(),
-      staticClass: 'weex-cell'
+      staticClass: 'weex-cell',
+      staticStyle: ms
     }, this.$slots.default)
   }
 }

--- a/html5/render/vue/components/scrollable/list/index.js
+++ b/html5/render/vue/components/scrollable/list/index.js
@@ -51,6 +51,7 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('list', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
+    const ms = this._getComponentStyle(this.$vnode.data)
 
     this.$nextTick(() => {
       this.updateLayout()
@@ -60,6 +61,7 @@ export default {
       ref: 'wrapper',
       attrs: { 'weex-type': 'list' },
       staticClass: this.wrapperClass,
+      staticStyle: ms,
       on: extend(this._createEventMap(), {
         scroll: this.handleListScroll,
         touchstart: this.handleTouchStart,

--- a/html5/render/vue/components/scrollable/loading-indicator.js
+++ b/html5/render/vue/components/scrollable/loading-indicator.js
@@ -1,10 +1,12 @@
 export default {
   name: 'loading-indicator',
   render (createElement) {
+    const ms = this._getComponentStyle(this.$vnode.data)
     this.weexType = 'loading-indicator'
     return createElement('mark', {
       attrs: { 'weex-type': 'loading-indicator' },
-      staticClass: 'weex-loading-indicator'
+      staticClass: 'weex-loading-indicator',
+      staticStyle: ms
     })
   }
 }

--- a/html5/render/vue/components/scrollable/loading.js
+++ b/html5/render/vue/components/scrollable/loading.js
@@ -78,10 +78,12 @@ export default {
     }
   },
   render (createElement) {
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('aside', {
       ref: 'loading',
       attrs: { 'weex-type': 'loading' },
-      staticClass: 'weex-loading'
+      staticClass: 'weex-loading',
+      staticStyle: ms
     }, this.getChildren())
   }
 }

--- a/html5/render/vue/components/scrollable/refresh.js
+++ b/html5/render/vue/components/scrollable/refresh.js
@@ -86,10 +86,12 @@ export default {
     }
   },
   render (createElement) {
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('aside', {
       ref: 'refresh',
       attrs: { 'weex-type': 'refresh' },
-      staticClass: 'weex-refresh'
+      staticClass: 'weex-refresh',
+      staticStyle: ms
     }, this.getChildren())
   }
 }

--- a/html5/render/vue/components/scrollable/scroller.js
+++ b/html5/render/vue/components/scrollable/scroller.js
@@ -79,10 +79,13 @@ export default {
       this.updateLayout()
     })
 
+    const ms = this._getComponentStyle(this.$vnode.data)
+
     return createElement('main', {
       ref: 'wrapper',
       attrs: { 'weex-type': 'scroller' },
       staticClass: this.wrapperClass,
+      staticStyle: ms,
       on: extend(this._createEventMap(), {
         scroll: this.handleScroll,
         touchstart: this.handleTouchStart,

--- a/html5/render/vue/components/scrollable/shared.js
+++ b/html5/render/vue/components/scrollable/shared.js
@@ -9,14 +9,18 @@ import loading from './loading'
 
 export function createLoading (context, createElement, vnode) {
   const options = vnode.componentOptions
+  const ms = context._getComponentStyle(context.$vnode.data)
   return createElement(loading, extend(vnode.data, {
-    on: options.listeners
+    on: options.listeners,
+    staticStyle: ms
   }), options.children)
 }
 
 export function createRefresh (context, createElement, vnode) {
   const options = vnode.componentOptions
+  const ms = context._getComponentStyle(context.$vnode.data)
   return createElement(refresh, extend(vnode.data, {
-    on: options.listeners
+    on: options.listeners,
+    staticStyle: ms
   }), options.children)
 }

--- a/html5/render/vue/components/slider/index.js
+++ b/html5/render/vue/components/slider/index.js
@@ -57,18 +57,20 @@ export default {
           staticClass: 'weex-slider-cell'
         }, [vnode])
       })
-      indicatorVnode.data.attrs = indicatorVnode.data.attrs || {}
-      indicatorVnode.data.attrs.count = cells.length
-      indicatorVnode.data.attrs.active = this.currentIndex
-      // this._indicator = createElement(indicator, {
-      //   staticClass: indicatorVnode.data.staticClass,
-      //   staticStyle: indicatorVnode.data.staticStyle,
-      //   attrs: {
-      //     count: cells.length,
-      //     active: this.currentIndex
-      //   }
-      // })
-      this._indicator = createElement(indicator, indicatorVnode.data)
+      if (indicatorVnode) {
+        indicatorVnode.data.attrs = indicatorVnode.data.attrs || {}
+        indicatorVnode.data.attrs.count = cells.length
+        indicatorVnode.data.attrs.active = this.currentIndex
+        // this._indicator = createElement(indicator, {
+        //   staticClass: indicatorVnode.data.staticClass,
+        //   staticStyle: indicatorVnode.data.staticStyle,
+        //   attrs: {
+        //     count: cells.length,
+        //     active: this.currentIndex
+        //   }
+        // })
+        this._indicator = createElement(indicator, indicatorVnode.data)
+      }
       return cells
     }
   },

--- a/html5/render/vue/components/slider/indicator.js
+++ b/html5/render/vue/components/slider/indicator.js
@@ -9,7 +9,7 @@ function getIndicatorItemStyle (spec, isActive) {
 
 function _render (context, h) {
   const children = []
-  const { staticStyle: mergedStyle } = context.$vnode.data
+  const mergedStyle = context._getComponentStyle(context.$vnode.data)
   context.$vnode.data.cached = {}
   extendKeys(context.$vnode.data.cached, mergedStyle, ['width', 'height'])
   const indicatorSpecStyle = extendKeys(

--- a/html5/render/vue/components/slider/slideMixin.js
+++ b/html5/render/vue/components/slider/slideMixin.js
@@ -64,12 +64,8 @@ export default {
     },
 
     handleTouchStart (event) {
-      event.preventDefault()
       event.stopPropagation()
-      // console.log('touch start', event)
       const touch = event.changedTouches[0]
-      // console.log('touch start', event.target, event.target.pageY)
-      // console.log('touches', touch)
       this._touchParams = {
         originalTransform: this.$refs.inner.style.transform,
         startTouchEvent: touch,
@@ -77,19 +73,41 @@ export default {
         startY: touch.pageY,
         timeStamp: event.timeStamp
       }
+      // // check if is vertical scrolling in 25 milliseconds.
+      // setTimeout(() => {
+      //   // if didn't cancel.
+      //   const tp = this._touchParams
+      //   if (tp) {
+      //     tp.isVertical = tp.offsetY > tp.offsetX
+      //     console.log('this.isVertical', tp.isVertical)
+      //   }
+      // }, 100)
     },
 
     handleTouchMove (event) {
-      event.preventDefault()
       event.stopPropagation()
-      // console.log('touch move')
+      // console.log('isVertical:', this._touchParams && this._touchParams.isVertical)
+      // if (this._touchParams && this._touchParams.isVertical) {
+        // return
+      // }
+      // else if
       if (this._touchParams) {
+        // event.preventDefault()
         const inner = this.$refs.inner
-        const { startX } = this._touchParams
+        const { startX, startY } = this._touchParams
         const touch = event.changedTouches[0]
         const offsetX = touch.pageX - startX
+        const offsetY = touch.pageY - startY
         // console.log('offsetX', offsetX, 'startX', startX, 'pageX', touch.pageX)
         this._touchParams.offsetX = offsetX
+        this._touchParams.offsetY = offsetY
+
+        // only for the first time clac.
+        // if (typeof this._touchParams.isVertical === 'undefined') {
+        //   const isVertical = offsetY > offsetX
+        //   this._touchParams.isVertical = isVertical
+        //   if (isVertical) { return }
+        // }
 
         if (inner && offsetX) {
           inner.style.transform = `translate3d(${this.innerOffset + offsetX}px, 0, 0)`
@@ -98,11 +116,10 @@ export default {
     },
 
     handleTouchEnd (event) {
-      event.preventDefault()
       event.stopPropagation()
       // console.log('touch end')
       const inner = this.$refs.inner
-      if (this._touchParams) {
+      if (this._touchParams/* && !this._touchParams.isVertical*/) {
         const { offsetX } = this._touchParams
         if (inner) {
           const reset = Math.abs(offsetX / this.wrapperWidth) < 0.2

--- a/html5/render/vue/components/switch.js
+++ b/html5/render/vue/components/switch.js
@@ -40,7 +40,6 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('switch', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
     return createElement('span', {
       attrs: { 'weex-type': 'switch' },
       staticClass: this.wrapperClass,

--- a/html5/render/vue/components/text.js
+++ b/html5/render/vue/components/text.js
@@ -32,17 +32,13 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('text', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
+    const ms = this._getComponentStyle(this.$vnode.data)
 
     return createElement('p', {
       attrs: { 'weex-type': 'text' },
       on: this._createEventMap(),
-      staticClass: 'weex-text'
+      staticClass: 'weex-text',
+      staticStyle: extend(ms, getTextSpecStyle(this))
     }, this.$slots.default || [this.value])
-  },
-
-  methods: {
-    beforeRender () {
-      extend(this.$options._parentVnode.data.staticStyle, getTextSpecStyle(this))
-    }
   }
 }

--- a/html5/render/vue/components/textarea.js
+++ b/html5/render/vue/components/textarea.js
@@ -24,7 +24,7 @@ export default {
     // if (process.env.NODE_ENV === 'development') {
     //   validateStyles('textarea', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
-
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('html:textarea', {
       attrs: {
         'weex-type': 'textarea',
@@ -35,7 +35,8 @@ export default {
         rows: this.rows
       },
       on: extend(this._createEventMap(), mapFormEvents(this)),
-      staticClass: 'weex-textarea'
+      staticClass: 'weex-textarea',
+      staticStyle: ms
     }, this.value)
   }
 }

--- a/html5/render/vue/components/web.js
+++ b/html5/render/vue/components/web.js
@@ -39,13 +39,15 @@ export default {
     //   validateStyles('web', this.$vnode.data && this.$vnode.data.staticStyle)
     // }
 
+    const ms = this._getComponentStyle(this.$vnode.data)
     return createElement('iframe', {
       attrs: {
         'weex-type': 'web',
         src: this.src
       },
       on: this._createEventMap(['error']),
-      staticClass: 'weex-web'
+      staticClass: 'weex-web',
+      staticStyle: ms
     })
   }
 }

--- a/html5/render/vue/env/viewport.js
+++ b/html5/render/vue/env/viewport.js
@@ -19,7 +19,7 @@ export function setViewport (config = {}) {
     // const viewportWidth = parseViewportWidth(config)
 
     // set root font-size
-    doc.documentElement.style.fontSize = viewportWidth / 10 + 'px'
+    // doc.documentElement.style.fontSize = viewportWidth / 10 + 'px'
 
     /**
      * why not to use window.screen.width to get screenWidth ? Because in some

--- a/html5/render/vue/mixins/base.js
+++ b/html5/render/vue/mixins/base.js
@@ -38,15 +38,9 @@ export default {
       watchLazyload()
     }
   },
-  created () {
-    this._prerender()
-  },
+
   mounted () {
     watchAppear(this)
-  },
-
-  beforeUpdate () {
-    this._prerender()
   },
 
   methods: {
@@ -87,12 +81,6 @@ export default {
     _fireLazyload () {
       const scroller = this._getParentScroller()
       fireLazyload(scroller && scroller.$el || document.body)
-    },
-
-    _prerender () {
-      this._mergeStyles()
-      // process prerender hooks for components' own treatment.
-      this.beforeRender && this.beforeRender()
     }
   }
 }

--- a/html5/render/vue/mixins/base.js
+++ b/html5/render/vue/mixins/base.js
@@ -61,6 +61,7 @@ export default {
     },
 
     _getScopeId () {
+      // return closest scopeId.
       let scopeId = this.$options._scopeId
       let ctx = this
       while (!scopeId) {

--- a/html5/render/vue/mixins/base.js
+++ b/html5/render/vue/mixins/base.js
@@ -61,8 +61,14 @@ export default {
     },
 
     _getScopeId () {
-      const ctx = this._getTopContext()
-      return ctx.$options._scopeId
+      let scopeId = this.$options._scopeId
+      let ctx = this
+      while (!scopeId) {
+        ctx = ctx.$options.parent
+        if (!ctx) return null
+        scopeId = ctx.$options._scopeId
+      }
+      return scopeId
     },
 
     _getParentScroller () {

--- a/html5/render/vue/mixins/style.js
+++ b/html5/render/vue/mixins/style.js
@@ -16,12 +16,12 @@ function getHeadStyleMap () {
       // why not using styleSheet.rules || styleSheet.cssRules to get css rules ?
       // because weex's components defined non-standard style attributes, which is
       // auto ignored when access rule.cssText.
-      const strArr = styleSheet.ownerNode.textContent.trim().split(/\.(?!\d+)/)
+      const strArr = trimComment(styleSheet.ownerNode.textContent.trim()).split(/\.(?!\d+)/)
       const len = strArr.length
       const rules = []
       for (let i = 0; i < len; i++) {
         const str = strArr[i]
-        if (!str) {
+        if (!str || str.match(/^\s*$/)) {
           continue
         }
         const match = str.match(/^([^{\s]+)\s*{\s*([^}]+)}\s*$/)

--- a/html5/render/vue/styles/components.css
+++ b/html5/render/vue/styles/components.css
@@ -63,6 +63,7 @@ figure, img, .weex-image, .weex-img {
   display: block;
   position: relative;
   background-repeat: no-repeat;
+  background-position: 50% 50%;
 }
 
 .weex-toast {

--- a/html5/render/vue/utils/func.js
+++ b/html5/render/vue/utils/func.js
@@ -2,6 +2,7 @@
  * Mix properties into target object.
  */
 export function extend (to, from) {
+  if (!from) { return to }
   for (const key in from) {
     to[key] = from[key]
   }
@@ -12,6 +13,7 @@ export function extend (to, from) {
  * Mix specified properties into target object.
  */
 export function extendKeys (to, from, keys) {
+  if (!from) { return to }
   (keys || []).forEach(key => {
     to[key] = from[key]
   })
@@ -22,6 +24,7 @@ export function extendKeys (to, from, keys) {
  * Extract specified properties from src to target object.
  */
 export function extractKeys (to, from, keys) {
+  if (!from) { return to }
   (keys || []).forEach(key => {
     to[key] = from[key]
     delete from[key]

--- a/vue.html
+++ b/vue.html
@@ -13,7 +13,7 @@
    <script src="./node_modules/vue/dist/vue.runtime.js"></script> 
   <!-- <script src="dist/vue.runtime.js"></script> -->
   <!-- <script src="./node_modules/weex-vue-render/index.min.js"></script> -->
-  <script src="./packages/weex-vue-render/index.js"></script>
+  <script src="./packages/weex-vue-render/dist/index.js"></script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
* fix image size attribute: image not centralized.
* fix merging style algorithm.
* fix lifecycle hook (mainly the beforeUpdate).
* rm root font-size, no support for rem any more.
* fix slider: can’t panmove vertically if it’s in a scoller.
* firelazyload in a throttle way, every 16 ms.