### PR TITLE
[html5] fix img lazyload when body's content overflowed.

### DIFF
--- a/html5/render/vue/utils/component.js
+++ b/html5/render/vue/utils/component.js
@@ -20,13 +20,15 @@ export function hasIntersection (rect, ctRect) {
  * @param  {HTMLElement}  container  optional, the container of this el.
  */
 export function isElementVisible (el, container) {
-  const ctRect = container && container.getBoundingClientRect()
-    || {
-      top: 0,
-      left: 0,
-      bottom: window.innerHeight,
-      right: window.innerWidth
-    }
+  const bodyRect = {
+    top: 0,
+    left: 0,
+    bottom: window.innerHeight,
+    right: window.innerWidth
+  }
+  const ctRect = (container === document.body)
+    ? bodyRect : container
+    ? container.getBoundingClientRect() : bodyRect
   return hasIntersection(
     el.getBoundingClientRect(),
     ctRect)


### PR DESCRIPTION
fix image lazyload when body's content overflowed (height's value is bigger than body).