### PR TITLE
[html5] indicator component's bug

### DIFF
--- a/html5/render/vue/components/slider/indicator.js
+++ b/html5/render/vue/components/slider/indicator.js
@@ -70,11 +70,11 @@ function _getLtbr (context, mergedStyle) {
  * get indicator's rect (width, height).
  */
 function _getIndicatorRect (el) {
-  let width, height
+  let width = 0, height = 0
   if (el.children.length === 1) {
     width = height = window.getComputedStyle(el.children[0])
   }
-  else {
+  if (el.children.length > 1){
     const itemComputedStyle = window.getComputedStyle(el.children[1])
     const padding = parseFloat(itemComputedStyle.marginLeft)
     height = parseFloat(itemComputedStyle.height)


### PR DESCRIPTION
apache仓库不是最新的代码，所以在这里提交了。
第一次加载没有获取到children，导致el.children[1]报错
_getIndicatorRect也没有做children.length=0的判断处理

还有很多reset样式优先级都很高
如：`.weex-root p, .weex-root ol, .weex-root ul, .weex-root dl{margin:0;padding:0;}`高于一切
望处理一下。