### PR TITLE
[ios] fix: only call component method when component exist

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXComponentMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXComponentMethod.m
@@ -48,6 +48,7 @@
         WXComponent *component = [self.instance componentForRef:_componentRef];
         if (!component) {
             WXLogError(@"component not found for ref:%@, type:%@", _componentRef, _componentName);
+            return;
         }
         BOOL synchronous = NO;
         SEL selector = [WXComponentFactory methodWithComponentName:component.type withMethod:self.methodName isSync:&synchronous];


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
