### PR TITLE
BroadCastChannel Memory Leak

### DIFF
--- a/runtime/services/broadcast-channel/index.js
+++ b/runtime/services/broadcast-channel/index.js
@@ -69,6 +69,7 @@ BroadcastChannel.prototype.close = function () {
   }
 
   this._closed = true
+  this.onmessage = null
 
   // remove itself from channels.
   if (channels[this.name]) {


### PR DESCRIPTION
在同页面中不停的切换，导致内存无法释放，代码片段如下：
data(){
    return {
        BroadcastNotice:new BroadcastChannel('notice111111')
    }
},
created() {
    this.BroadcastNotice.onmessage = event => this.$emit("onNoticeMsg", event) //泄露
    // this.HundsunNotice.onmessage = event => {}  //正常

},

<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
