### PR TITLE
[core] fix containing block size of absolutely positioned element

### DIFF
--- a/weex_core/Source/core/layout/layout.cpp
+++ b/weex_core/Source/core/layout/layout.cpp
@@ -90,6 +90,12 @@ namespace WeexCore {
       switch (mCssStyle->mPositionType) {
         case kAbsolute:
           containingBlockWidth = mParent->mLayoutResult->mLayoutSize.width;
+          if (!isnan(mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthLeft))) {
+            containingBlockWidth -= mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthLeft);
+          }
+          if (!isnan(mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthRight))) {
+            containingBlockWidth -= mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthRight);
+          }
           break;
         case kFixed:
           if (!isnan(renderPageWidth)) {
@@ -126,6 +132,12 @@ namespace WeexCore {
       switch (mCssStyle->mPositionType) {
         case kAbsolute:
           containingBlockHeight = mParent->mLayoutResult->mLayoutSize.height;
+          if (!isnan(mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthTop))) {
+            containingBlockHeight -= mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthTop);
+          }
+          if (!isnan(mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthBottom))) {
+            containingBlockHeight -= mParent->mCssStyle->mBorderWidth.getBorderWidth(kBorderWidthBottom);
+          }
           break;
         case kFixed:
           if (!isnan(renderPageHeight)) {


### PR DESCRIPTION
Fix http://dotwe.org/vue/8d92197521649a17842fddf7cf67cc76

<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

According to this [reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block):

> If the position property is absolute, the containing block is formed by the edge of the ***padding box*** of the nearest ancestor element that has a position value other than static (fixed, absolute, relative, or sticky).

The border of the ancestor element should be excluded when calculating the size of the containing block.

![pr](https://user-images.githubusercontent.com/40169025/167253462-6c3662c6-8683-4841-9e50-8611991bcfe4.jpg)

# Checklist
* Demo:
http://dotwe.org/vue/8d92197521649a17842fddf7cf67cc76
* Documentation:

<!-- # Additional content -->
