### PR TITLE
[ios] fix date/time input is not firing input event

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.mm
@@ -633,6 +633,14 @@ WX_EXPORT_METHOD(@selector(setTextFormatter:))
     }
 }
 
+- (void)datePickerValueDidChange:(NSString *)value
+{
+    self.text = value;
+    if (_inputEvent) {
+        [self fireEvent:@"input" params:@{@"value":[self text]} domChanges:@{@"attrs":@{@"value":[self text]}}];
+    }
+}
+
 #pragma mark UITextFieldDelegate
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField{

--- a/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.h
@@ -22,6 +22,7 @@
 @protocol WXDatePickerManagerDelegate <NSObject>
 @optional
 - (void)fetchDatePickerValue:(NSString *)value;
+- (void)datePickerValueDidChange:(NSString *)value;
 @end
 
 @interface WXDatePickerManager : NSObject

--- a/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.m
@@ -71,6 +71,7 @@
         CGRect pickerFrame = CGRectMake(0, 44, [UIScreen mainScreen].bounds.size.width, WXPickerHeight-44);
         datePicker.backgroundColor = [UIColor whiteColor];
         datePicker.frame = pickerFrame;
+        [datePicker addTarget:self action:@selector(valueChanged:) forControlEvents:UIControlEventValueChanged];
         UIToolbar *toolBar=[[UIToolbar alloc]initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, 44)];
         [toolBar setBackgroundColor:[UIColor whiteColor]];
         UIBarButtonItem* noSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
@@ -217,6 +218,19 @@
         [self.delegate fetchDatePickerValue:value];
     }
     
+}
+
+- (void)valueChanged:(id)sender
+{
+    if ([self.delegate respondsToSelector:@selector(datePickerValueDidChange:)]) {
+        NSString *value = @"";
+        if ([_type isEqualToString:@"time"]) {
+            value = [WXUtility timeToString:self.datePicker.date];
+        } else if ([_type isEqualToString:@"date"]) {
+            value = [WXUtility dateToString:self.datePicker.date];
+        }
+        [self.delegate datePickerValueDidChange:value];
+    };
 }
 
 #pragma mark - UIGestureRecognizerDelegate


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
`<input>` component with `type="date"` or `type="time"` is not firing `input` event.

The following use cases are affected:
```
<input type="date" @input="oninput" />
<input type="date" v-model="value" />
```
# Checklist
* Demo:
* http://dotwe.org/vue/efd4facfe662af7c53c064d17e386c63
* Documentation:

<!-- # Additional content -->
