### PR TITLE
[ios] fix incorrect initial text inset of textarea

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.mm
@@ -48,6 +48,7 @@ typedef UITextView WXTextAreaView;
         self.placeHolderLabel.numberOfLines = 0;
         [_textView addSubview:self.placeHolderLabel];
     }
+    [self _updateTextContentInset];
     // default placeholder hide from voice over
     self.placeHolderLabel.isAccessibilityElement = NO;
     _textView.isAccessibilityElement = YES;


### PR DESCRIPTION
Fix http://dotwe.org/vue/d4a31131178b9ab11f6dd05e5792a171

<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
`<textarea>`component has incorrect text insets upon initialization, and it doesn't become correct until the border/padding changes which will trigger an update of insets.
# Checklist
* Demo:
http://dotwe.org/vue/d4a31131178b9ab11f6dd05e5792a171
* Documentation:

<!-- # Additional content -->
