### PR TITLE
[ios]Fix the problem that when the list is under one piece of data, the loading label will be displayed by default in the drop-down refresh list

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.mm
@@ -1350,7 +1350,9 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
-    [_loadingComponent.view setHidden:NO];
+    if ([_loadingComponent displayState]) {
+        [_loadingComponent.view setHidden:NO];
+    }
     [_refreshComponent.view setHidden:NO];
     
     //refresh


### PR DESCRIPTION
Fix the problem that when the list is under one piece of data, the loading label will be displayed by default in the drop-down refresh list

原因:
下拉动作结束时，触发了scrollerview的scrollViewDidEndDragging逻辑，该逻辑中没有考虑list列表不满一屏的场景，导致默认设置loading标签的hidden为NO

解决方案:
scrollViewDidEndDragging方法中增加loading标签的displayState属性判断

<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
