### PR TITLE
[ios]Fixed the problem that the list was not automatically restored when the loading tag was pulled up under certain conditions

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXLoadingComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXLoadingComponent.mm
@@ -122,9 +122,13 @@
     }
     if (contentOffset.y > 0) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [UIView animateWithDuration:0.25 animations:^{
-                [scrollerProtocol setContentOffset:contentOffset animated:NO];
-            } completion:nil];
+            if (_displayState) {
+                [scrollerProtocol setContentOffset:contentOffset animated:YES];
+            } else {
+                [UIView animateWithDuration:0.25 animations:^{
+                    [scrollerProtocol setContentOffset:contentOffset];
+                } completion:nil];
+            }
         });
     }
 }


### PR DESCRIPTION
Fix the problem that when the list is under one piece of data, the loading label will be displayed by default in the drop-down refresh list

复现条件:
list标签数据不超过一屏时，同时存在refresh和loading标签，若上拉加载列表(没有更多数据)，仅仅快速切换(100ms)loading标签的display属性由true为false，发现列表位置不会自动还原

原因:
Probably setContentOffset: has higher priority than setContentOffset:animated:

方案:
参考refresh标签的说明，针对displayState字段不同值，调整设置setContentOffset方式

<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:http://dotwe.org/vue/ab6efd1b38c9beaec2cae3a99e3ecf79
<template>
  <list>
    <refresh class="refresh" @refresh="onrefresh" @pullingdown="onpullingdown" :display="refreshing ? 'show' : 'hide'">
      <text class="indicator-text">Refreshing ...</text>
      <loading-indicator class="indicator"></loading-indicator>
    </refresh>
    <cell v-for="num in lists">
      <text class="text">{{num}}</text>
    </cell>
    <loading class="loading" @loading="onloading" :display="loadinging ? 'show' : 'hide'">
      <text class="indicator-text">Loading ...</text>
      <loading-indicator class="indicator"></loading-indicator>
    </loading>
  </list>
</template>

<script>
  const modal = weex.requireModule('modal')

  export default {
    data () {
      return {
        refreshing: false,
        loadinging: false,
        lists: [1, 2, 3, 4, 5]
      }
    },
    methods: {
      onrefresh (event) {
        modal.toast({ message: 'Refreshing', duration: 1 })
        this.refreshing = true
        setTimeout(() => {
          this.refreshing = false
        }, 2000)
      },
      onpullingdown (event) {
        console.log("dy: " + event.dy)
        console.log("pullingDistance: " + event.pullingDistance)
        console.log("viewHeight: " + event.viewHeight)
        console.log("type: " + event.type)
      },
      onloading (event) {
        modal.toast({ message: 'Loading', duration: 1 })
        this.loadinging = true
        setTimeout(() => {
          this.loadinging = false
        }, 2000)
      },
    }
  }
</script>

<style scoped>
  .refresh {
    width: 750px;
    height: 180px;
    background-color: #333;
    display: -ms-flex;
    display: -webkit-flex;
    display: flex;
    -ms-flex-align: center;
    -webkit-align-items: center;
    -webkit-box-align: center;
    align-items: center;
  }
  .indicator-text {
    color: #EEE;
    font-size: 42px;
    text-align: center;
  }
  .indicator {
    margin-top: 16px;
    height: 40px;
    width: 40px;
    color: blue;
  }
  .panel {
    width: 600px;
    height: 250px;
    margin-left: 75px;
    margin-top: 35px;
    margin-bottom: 35px;
    flex-direction: column;
    justify-content: center;
    border-width: 2px;
    border-style: solid;
    border-color: #DDDDDD;
    background-color: #F5F5F5;
  }
  .text {
    font-size: 50px;
    text-align: center;
    color: #41B883;
  }
</style>
* Documentation:

<!-- # Additional content -->
