### PR TITLE
[ios]fix complie issue with xcode13 Undefined symbols ___gcov_flush

### DIFF
--- a/playground/ios/WeexDemo/AppDelegate.m
+++ b/playground/ios/WeexDemo/AppDelegate.m
@@ -103,8 +103,8 @@
     setenv("GCOV_PREFIX", [documentsDirectory cStringUsingEncoding:NSUTF8StringEncoding], 1);
     setenv("GCOV_PREFIX_STRIP", "6", 1);
 #endif
-    extern void __gcov_flush(void);
-    __gcov_flush();
+    extern void __gcov_reset(void);
+    __gcov_reset();
 #endif
 }
 

--- a/playground/ios/WeexDemo/WXExtModule.m
+++ b/playground/ios/WeexDemo/WXExtModule.m
@@ -36,8 +36,8 @@ WX_EXPORT_METHOD(@selector(generateCover:))
 #if defined __cplusplus
     extern "C" {
 #endif
-    extern void __gcov_flush(void);
-    __gcov_flush();
+    extern void __gcov_reset(void);
+        __gcov_reset();
 #if defined __cplusplus
     };
 #endif


### PR DESCRIPTION
fix complie issue with xcode13 Undefined symbols ___gcov_flush

原因：
 llvm delete "_gcov_flush", try replace with "__gcov_dump/__gcov_reset" , https://reviews.llvm.org/D83149

<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:
![image](https://user-images.githubusercontent.com/3312112/170028683-5a329a69-dbcf-424b-a736-c54b69c3cf08.png)

<!-- # Additional content -->
