### PR TITLE
[ios]fix convert empty array issues

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeMethod.m
@@ -125,7 +125,8 @@
         if (!strcmp(parameterType, blockType)) {
             // callback
             argument = [^void(id result, BOOL keepAlive) {
-                [[WXSDKManager bridgeMgr] callBack:instanceId funcId:(NSString *)obj params:[WXUtility convertContainerToImmutable:result] keepAlive:keepAlive];
+                // When we execute the callback processing, we perform a one-step convertContainerToImmutable operation (convert the object into an object). For NSArray objects with different empty elements, they are converted to NSMutableArray, and then converted to multiple objects, so the front of json points to the same an object.
+                [[WXSDKManager bridgeMgr] callBack:instanceId funcId:(NSString *)obj params:result keepAlive:keepAlive];
             } copy];
             
             // retain block


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
When eex executes the callback processing, it performs a one-step convertContainerToImmutable operation (converting the object into an object). For NSArray objects with different empty elements, it is converted to NSMutableArray and converted to multiple objects, so the front of json points to the same object.
# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
