### PR TITLE
[ios]fix date|time reset issues

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.mm
@@ -640,6 +640,8 @@ WX_EXPORT_METHOD(@selector(setTextFormatter:))
     {
         [[[UIApplication sharedApplication] keyWindow] endEditing:YES];
         _changeEventString = [textField text];
+        //Fix the problem that the date display time is incorrect after the initial value of the date is reset when the input tag type is date|time
+        [_datePickerManager updateDatePicker:@{@"value":_changeEventString,@"type":_inputType}];
         [_datePickerManager show];
         return NO;
     }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
Fix the problem that the date display time is incorrect after the initial value of the date is reset when the input tag type is date|time
# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
