### PR TITLE
[ios]fix maxlength issues

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.mm
@@ -127,6 +127,14 @@ WX_EXPORT_METHOD(@selector(setTextFormatter:))
         if (attributes[@"maxlength"]) {
             _maxLength = [NSNumber numberWithUnsignedInteger:[attributes[@"maxlength"] integerValue]];
         }
+
+        /*
+         maxlength=5, but set the default value to 12 lengths. Before the 5th character, pasting 10 characters directly will result in As a result, the length of leftLength=17 is larger than the position of the cursor and larger than maxleng, and the extra characters need to be filtered.
+         */
+        if (_maxLength && [_value length] > [_maxLength integerValue]&& [_maxLength integerValue] >= 0) {
+            _value = [_value substringToIndex:([_maxLength integerValue])];
+        }
+
         if (attributes[@"returnKeyType"]) {
             _returnKeyType = [WXConvert UIReturnKeyType:attributes[@"returnKeyType"]];
         }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
maxlength=5, but set the default value to 12 lengths. Before the 5th character, pasting 10 characters directly will result in
         As a result, the length of leftLength=17 is larger than the position of the cursor and larger than maxleng, and the extra characters need to be filtered.
# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
