### PR TITLE
[ios]fix jsn-dom addRule may crashed in iOS13.4+

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -703,7 +703,7 @@ static BOOL gIsEnvironmentUsingDarkScheme = NO;
         NSURL * downloadPath = nil;
         NSError * error = nil;
         NSHTTPURLResponse * httpResponse = (NSHTTPURLResponse*)response;
-        if (200 == httpResponse.statusCode) {
+        if (([httpResponse isKindOfClass:NSHTTPURLResponse.class] && 200 == httpResponse.statusCode) || (![httpResponse isKindOfClass:NSHTTPURLResponse.class] && data)) {
             NSString *file = [NSString stringWithFormat:@"%@/%@",WX_FONT_DOWNLOAD_DIR,[WXUtility md5:[url absoluteString]]];
             downloadPath = [NSURL fileURLWithPath:file];
             NSFileManager *mgr = [NSFileManager defaultManager];
@@ -718,9 +718,7 @@ static BOOL gIsEnvironmentUsingDarkScheme = NO;
                 downloadPath = nil;
             }
         } else {
-            if (200 != httpResponse.statusCode) {
-                error = [NSError errorWithDomain:WX_ERROR_DOMAIN code:-1 userInfo:@{@"ErrorMsg": [NSString stringWithFormat:@"can not load the font url %@ ", url.absoluteString]}];
-            }
+            error = [NSError errorWithDomain:WX_ERROR_DOMAIN code:-1 userInfo:@{@"ErrorMsg": [NSString stringWithFormat:@"can not load the font url %@ ", url.absoluteString]}];
         }
         completionBlock(downloadPath, error);
 


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
jsn-dom addRule  method when src   is base64 iconfont，will crashed in iOS13.4+
# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
