### PR TITLE
【安全测试】File.getAbsolutePath()方法获取文件路径，没有过滤“.\或.\”,存在跨路径攻击风险，推荐使用getCan…

### DIFF
--- a/android/sdk/src/main/java/org/apache/weex/WXEnvironment.java
+++ b/android/sdk/src/main/java/org/apache/weex/WXEnvironment.java
@@ -310,7 +310,7 @@ public class WXEnvironment {
         if (!desDir.exists()) {
           desDir.mkdirs();
         }
-        COPY_SO_DES_DIR = desDir.getAbsolutePath();
+        COPY_SO_DES_DIR = desDir.getCanonicalPath();
       }
     } catch (Throwable e) {
       WXLogUtils.e(WXLogUtils.getStackTrace(e));
@@ -473,7 +473,12 @@ public class WXEnvironment {
     if (dir == null)
         return "";
 
-    String crashDir = dir.getAbsolutePath();
+    String crashDir = null;
+    try {
+      crashDir = dir.getCanonicalPath();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
 
     return crashDir;
   }
@@ -523,7 +528,7 @@ public class WXEnvironment {
     final String soDesPath = copySoDesDir();
     if (sourceFile.exists() && !TextUtils.isEmpty(soDesPath)) {
       try {
-        WXFileUtils.extractSo(sourceFile.getAbsolutePath(), soDesPath);
+        WXFileUtils.extractSo(sourceFile.getCanonicalPath(), soDesPath);
       } catch (IOException e) {
         WXLogUtils.e("extractSo error " + e.getMessage());
 //        e.printStackTrace();
@@ -593,7 +598,11 @@ public class WXEnvironment {
       File soFile = new File(soPath);
       if (soFile.exists()) {
         WXLogUtils.e(libName + "'s Path is" + soPath);
-        return soFile.getAbsolutePath();
+        try {
+          return soFile.getCanonicalPath();
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
       } else {
         WXLogUtils.e(libName + "'s Path is " + soPath + " but file does not exist");
       }
@@ -608,10 +617,12 @@ public class WXEnvironment {
 
 
     if (cacheDir.indexOf("/cache") > 0) {
-      soPath = new File(cacheDir.replace("/cache", "/lib"), realName).getAbsolutePath();
+      try {
+        soPath = new File(cacheDir.replace("/cache", "/lib"), realName).getCanonicalPath();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
     }
-
-
     final File soFile = new File(soPath);
     if (soFile.exists()) {
       WXLogUtils.e(libName + "use lib so");
@@ -620,7 +631,11 @@ public class WXEnvironment {
       //unzip from apk file
       final String extractSoPath = extractSo();
       if (!TextUtils.isEmpty(extractSoPath)) {
-        return new File(extractSoPath, realName).getAbsolutePath();
+        try {
+          return new File(getCacheDir(), realName).getCanonicalPath();
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
       }
     }
     return soPath;

--- a/android/sdk/src/main/java/org/apache/weex/utils/TypefaceUtil.java
+++ b/android/sdk/src/main/java/org/apache/weex/utils/TypefaceUtil.java
@@ -147,9 +147,14 @@ public class TypefaceUtil {
         if(!dir.exists()){
           dir.mkdirs();
         }
-        final String fullPath =  dir.getAbsolutePath()+ File.separator +fileName;
-        if (!loadLocalFontFile(fullPath, fontFamily, false)) {
-          downloadFontByNetwork(url, fullPath, fontFamily);
+        final String fullPath;
+        try {
+          fullPath = dir.getCanonicalPath()+ File.separator +fileName;
+          if (!loadLocalFontFile(fullPath, fontFamily, false)) {
+            downloadFontByNetwork(url, fullPath, fontFamily);
+          }
+        } catch (IOException e) {
+          e.printStackTrace();
         }
       } else if (fontDo.getType() == FontDO.TYPE_FILE || fontDo.getType() == FontDO.TYPE_BASE64) {
         boolean result = loadLocalFontFile(fontDo.getUrl(), fontDo.getFontFamilyName(), false);

--- a/android/sdk/src/main/java/org/apache/weex/utils/WXFileUtils.java
+++ b/android/sdk/src/main/java/org/apache/weex/utils/WXFileUtils.java
@@ -253,7 +253,11 @@ public class WXFileUtils {
       inputStream.close();
       outputStream.close();
     } catch (Exception e) {
-      WXLogUtils.e("copyFile " + e.getMessage() + ": " + oldFile.getAbsolutePath() + ": " + newFile.getAbsolutePath());
+      try {
+        WXLogUtils.e("copyFile " + e.getMessage() + ": " + oldFile.getCanonicalPath() + ": " + newFile.getCanonicalPath());
+      } catch (IOException ioException) {
+        ioException.printStackTrace();
+      }
       if (inputStream != null) {
         try {
           inputStream.close();

--- a/android/sdk/src/main/java/org/apache/weex/utils/WXSoInstallMgrSdk.java
+++ b/android/sdk/src/main/java/org/apache/weex/utils/WXSoInstallMgrSdk.java
@@ -241,7 +241,7 @@ public class WXSoInstallMgrSdk {
         copyPath.mkdirs();
       }
       newfile = new File(copyPath, startSoPath);
-      WXEnvironment.CORE_JSB_SO_PATH = newfile.getAbsolutePath();
+      WXEnvironment.CORE_JSB_SO_PATH = newfile.getCanonicalPath();
       String jsb = WXEnvironment.getDefaultSettingValue(startSoName, "-1");
       if(newfile.exists() && TextUtils.equals(WXEnvironment.getAppVersionName(), jsb)) {
         // no update so skip copy
@@ -307,7 +307,7 @@ public class WXSoInstallMgrSdk {
         if (!TextUtils.equals(WXEnvironment.getAppVersionName(),defaultSettingValue)){
           targetFile.delete();
         }else {
-          WXEnvironment.CORE_JSS_SO_PATH= targetFile.getAbsolutePath();
+          WXEnvironment.CORE_JSS_SO_PATH= targetFile.getCanonicalPath();
           WXEnvironment.sUseRunTimeApi = true;
           WXLogUtils.e("weex", "copyJssRuntimeSo exist:  return");
           return;
@@ -321,7 +321,7 @@ public class WXSoInstallMgrSdk {
       targetFile.createNewFile();
       WXFileUtils.copyFileWithException(new File(fromPath),targetFile);
       /**3. update flag **/
-      WXEnvironment.CORE_JSS_SO_PATH= targetFile.getAbsolutePath();
+      WXEnvironment.CORE_JSS_SO_PATH= targetFile.getCanonicalPath();
       WXEnvironment.writeDefaultSettingsValue(keyVersionCode,WXEnvironment.getAppVersionName());
       WXEnvironment.sUseRunTimeApi = true;
       WXLogUtils.e("weex", "copyJssRuntimeSo: cp end and return ");

--- a/android/sdk/src/main/java/org/apache/weex/utils/WXViewToImageUtil.java
+++ b/android/sdk/src/main/java/org/apache/weex/utils/WXViewToImageUtil.java
@@ -115,15 +115,24 @@ public class WXViewToImageUtil {
         // Insert the image file into the system gallery
         try {
             MediaStore.Images.Media.insertImage(context.getContentResolver(),
-                    file.getAbsolutePath(), fileName, null);
-        } catch (FileNotFoundException e) {
+                    file.getCanonicalPath(), fileName, null);
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
         // Notify the system gallery update
-        context.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.parse("file://" + appDir.getAbsolutePath() + "/" + fileName)));
+        try {
+            context.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.parse("file://" + appDir.getCanonicalPath() + "/" + fileName)));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
-        return file.getAbsolutePath();
+        try {
+            return file.getCanonicalPath();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return "";
     }
 
     /**


### PR DESCRIPTION
The File. getAbsolutePath() method obtains the file path without filtering ". or. ". There is a risk of cross path attacks. It is recommended to use getCannonicalPath() to obtain the absolute path.

https://developer.android.com/reference/java/io/File

File.getAbsolutePath()方法获取文件路径，没有过滤“.\或.\”,存在跨路径攻击风险，推荐使用getCannonicalPath() 获取绝对路径。