### PR TITLE
[Android]fix leak when remove views.

### DIFF
--- a/android/sdk/src/main/java/org/apache/weex/ui/action/GraphicActionRemoveElement.java
+++ b/android/sdk/src/main/java/org/apache/weex/ui/action/GraphicActionRemoveElement.java
@@ -51,7 +51,7 @@ public class GraphicActionRemoveElement extends BasicGraphicAction {
   }
 
   private void clearRegistryForComponent(WXComponent component) {
-    WXComponent removedComponent = WXSDKManager.getInstance().getWXRenderManager().unregisterComponent(getPageId(), getRef());
+    WXComponent removedComponent = WXSDKManager.getInstance().getWXRenderManager().unregisterComponent(getPageId(), component.getRef());
     if (removedComponent != null) {
       removedComponent.removeAllEvent();
       removedComponent.removeStickyStyle();


### PR DESCRIPTION
<!-- First of all, thank you for your contribution!

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/alibaba/weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/alibaba/weex/blob/master/CONTRIBUTING.md#contribute-documentation)
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo: when make animations by js,some views has been removed from screen,but the native refs also exist in java class, if the aimations is run,the memeory leaks. and make this change, it will not happen. 
* Documentation:
    
<!-- # Additional content -->
