### PR TITLE
适配16KB pageSize，升级NDK27和配套Gradle工具链，替换ReactNative最新JSCore

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,26 +18,34 @@
  */
 buildscript {
     repositories {
+        maven { url 'https://maven.aliyun.com/repository/central' }
+        maven { url 'https://maven.aliyun.com/repository/jcenter' }
+        maven { url 'https://maven.aliyun.com/repository/public' }
+        maven { url 'https://maven.aliyun.com/repository/google' }
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:8.7.2'
     }
 }
 
 subprojects {
-    if(project.hasProperty('external_script')){
-        for(item in external_script.split()) {
+    if (project.hasProperty('external_script')) {
+        for (item in external_script.split()) {
             apply from: item
         }
     }
     repositories {
-        if(project.hasProperty('external_repositories')){
+        if (project.hasProperty('external_repositories')) {
             maven {
                 url external_repositories
             }
         }
+        maven { url 'https://maven.aliyun.com/repository/central' }
+        maven { url 'https://maven.aliyun.com/repository/jcenter' }
+        maven { url 'https://maven.aliyun.com/repository/public' }
+        maven { url 'https://maven.aliyun.com/repository/google' }
         google()
         jcenter()
     }
@@ -47,17 +55,21 @@ subprojects {
             classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         }
         repositories {
+            maven { url 'https://maven.aliyun.com/repository/central' }
+            maven { url 'https://maven.aliyun.com/repository/jcenter' }
+            maven { url 'https://maven.aliyun.com/repository/public' }
+            maven { url 'https://maven.aliyun.com/repository/google' }
             google()
             jcenter()
         }
     }
 }
 ext {
-    compileSdkVersion=28
-    minSdkVersion=14
-    targetSdkVersion=28
-    supportLibVersion="28.0.0"
-    fastjsonLibVersion="1.1.70.android"
+    compileSdkVersion = 28
+    minSdkVersion = 21
+    targetSdkVersion = 28
+    supportLibVersion = "28.0.0"
+    fastjsonLibVersion = "1.1.70.android"
     //Default value for disableCov is false
     disableCov = project.hasProperty("disableCov") && disableCov.equals("true")
     useApachePackageName = project.hasProperty('apachePackageName') ? project.property('apachePackageName').toBoolean() : false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,6 +11,7 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 #Mon Jun 27 20:06:22 CST 2016
-org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-android.enableD8=false
+#android.enableD8=true
+android.defaults.buildfeatures.buildconfig=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip

--- a/android/sdk/.gitignore
+++ b/android/sdk/.gitignore
@@ -15,6 +15,7 @@ assets/main.js
 assets/weex-main-jsfm.js
 assets/weex-rax-api.js
 .externalNativeBuild
+.cxx
 
 /libs/
 /src/main/jniLibs

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -17,19 +17,19 @@
  * under the License.
  */
  plugins {
-     id "com.github.hierynomus.license" version "0.14.0"
+//     id "com.github.hierynomus.license" version "0.14.0"
      id 'com.jfrog.artifactory' version '4.10.0'
  }
 
 apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'com.github.dcendents.android-maven'
+//apply plugin: 'com.github.dcendents.android-maven'
 
-apply from: 'buildSrc/jcenter.gradle'
+//apply from: 'buildSrc/jcenter.gradle'
 apply from: 'buildSrc/unstripped.gradle'
 apply from: 'buildSrc/checkStyle.gradle'
-apply from: 'buildSrc/download_jsc.gradle'
+//apply from: 'buildSrc/download_jsc.gradle'
 apply from: 'buildSrc/packageName.gradle'
 apply from: 'buildSrc/asan.gradle'
 
@@ -55,8 +55,15 @@ if (!project.hasProperty('ignoreVersionCheck') || !project.getProperty('ignoreVe
     }
 }
 
+android.buildFeatures.buildConfig true
+
 android {
+    buildFeatures {
+        buildConfig = true
+    }
+    namespace="com.taobao.weex"
     compileSdkVersion project.compileSdkVersion
+    ndkVersion "27.1.12297006"
     resourcePrefix "weex"
     useLibrary 'org.apache.http.legacy'
     if(project.hasProperty('removeSharedLib') && "true".equals(project.getProperty('removeSharedLib'))) {
@@ -99,7 +106,7 @@ android {
     if (ndkversion < 16) {
         api_level = "android-14";
     } else {
-        api_level = "android-16";
+        api_level = "android-24";
     }
 
     def android_project_dir = projectDir
@@ -145,8 +152,9 @@ android {
                         '-DANDROID_STL=' + "${cxx_stl}",
                         '-DCMAKE_BUILD_TYPE=Release',
                         '-DANDROID_PROJECT_DIR=' + "${android_project_dir}",
-                        '-DENABLE_ASAN=false'
-                if(buildRuntimeApi){
+                        '-DENABLE_ASAN=false',
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+                if (buildRuntimeApi) {
                     arguments '-DBUILD_RUNTIME_API='+"${buildRuntimeApi}"
                     if (initJSCPrivateApi){
                         arguments '-DINIT_JSC_PRIVATE_API='+"${initJSCPrivateApi}"
@@ -155,6 +163,7 @@ android {
                 if(project.hasProperty('enableASan') && "true" == project.getProperty('enableASan')) {
                     cppFlags "-fsanitize=address -fno-omit-frame-pointer"
                 }
+                version "3.22.1"
             }
         }
     }
@@ -199,6 +208,7 @@ android {
                 }
                 path 'src/legacyRelease/cpp/CMakeLists.txt'
             }
+            version "3.22.1"
         }
     }
 
@@ -263,32 +273,33 @@ dependencies {
     testImplementation 'org.json:json:20160212'
 }
 
-license {
-    header = file('../license/LICENSE')
-    mapping('cpp', 'JAVADOC_STYLE')
-    mapping('h', 'JAVADOC_STYLE')
-    excludes(['org/apache/weex/utils/WXDataStructureUtil.java'])
-}
+//license {
+//    header = file('../license/LICENSE')
+//    mapping('cpp', 'JAVADOC_STYLE')
+//    mapping('h', 'JAVADOC_STYLE')
+//    excludes(['org/apache/weex/utils/WXDataStructureUtil.java'])
+//}
 
-task weex_core_license(type: com.hierynomus.gradle.license.tasks.LicenseFormat) {
-    source = fileTree(dir: "../../weex_core").include(['**/*.h', '**/*.cpp', '**/*.cc', '**/*.c']).
-            exclude(['Source/rapidjson/**/*.h', 'Source/rapidjson/**/*.cpp',
-                     'Source/android/jniprebuild/jniheader/*.h',
-                     'Source/base/Compatible.cpp',
-                     'Source/IPC/**/*.h', 'Source/IPC/**/*.cpp', 'Source/IPC/**/*.c',
-                     'Source/base/base64/modp_base64/**/*.h',
-                     'Source/base/base64/modp_base64/**/*.cc',
-                     'Source/base/third_party/icu/*.h',
-                     'Source/base/third_party/icu/*.cpp',
-                     'Source/android/jsengine/dependence/**/*.h',
-                     'Source/android/jsengine/dependence/**/*.cpp',
-                     'Source/include/wtf/**/*.h',
-                     'Source/include/wtf/**/*.c',
-                     'Source/include/wtf/**/*.cpp',
-                     'Source/include/JavaScriptCore/**/*.h',
-                     'Source/include/JavaScriptCore/**/*.c',
-                     'Source/include/JavaScriptCore/**/*.cpp'])
-}
+//task weex_core_license(type: com.hierynomus.gradle.license.tasks.LicenseFormat) {
+//    source = fileTree(dir: "../../weex_core").include(['**/*.h', '**/*.cpp', '**/*.cc', '**/*.c']).
+//            exclude(['Source/rapidjson/**/*.h', 'Source/rapidjson/**/*.cpp',
+//                     'Source/android/jniprebuild/jniheader/*.h',
+//                     'Source/base/Compatible.cpp',
+//                     'Source/IPC/**/*.h', 'Source/IPC/**/*.cpp', 'Source/IPC/**/*.c',
+//                     'Source/base/base64/modp_base64/**/*.h',
+//                     'Source/base/base64/modp_base64/**/*.cc',
+//                     'Source/base/third_party/icu/*.h',
+//                     'Source/base/third_party/icu/*.cpp',
+//                     'Source/android/jsengine/dependence/**/*.h',
+//                     'Source/android/jsengine/dependence/**/*.cpp',
+//                     'Source/include/wtf/**/*.h',
+//                     'Source/include/wtf/**/*.c',
+//                     'Source/include/wtf/**/*.cpp',
+//                     'Source/include/JavaScriptCore/**/*.h',
+//                     'Source/include/JavaScriptCore/**/*.c',
+//                     'Source/include/JavaScriptCore/**/*.cpp'])
+//}
 
-preBuild.dependsOn licenseFormat, copyJSCHeaderToWeexCore
+//preBuild.dependsOn licenseFormat, copyJSCHeaderToWeexCore
+preBuild.dependsOn copyJSCHeaderToWeexCore
 clean.dependsOn cleanCopyJSCHeaderToWeexCore

--- a/android/sdk/buildSrc/download_jsc.gradle
+++ b/android/sdk/buildSrc/download_jsc.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 def jsc_dir = new File(project.buildDir, 'jsc')
-def jsc_url = project.hasProperty('jsc_url') ? new URL(project.getProperty('jsc_url').toString()) : new URL('https://registry.npmjs.org/jsc-android/-/jsc-android-241213.1.0.tgz')
+def jsc_url = project.hasProperty('jsc_url') ? new URL(project.getProperty('jsc_url').toString()) : new URL('https://www.n7shadowjoker.com/download/jsc-android-2026004.0.1.tgz')
 def aar_name = project.hasProperty('aar_name') ? project.getProperty('aar_name').toString() : 'android-jsc-intl'
 
 def jsc_file = new File(jsc_dir, jsc_url.path.split('/').last())

--- a/android/sdk/buildSrc/jcenter.gradle
+++ b/android/sdk/buildSrc/jcenter.gradle
@@ -114,7 +114,7 @@ artifactory {
             maven = true
         }
         defaults {
-            publications ('artifactorySnapthost')
+//            publications ('artifactorySnapthost')
         }
     }
 }

--- a/android/sdk/buildSrc/packageName.gradle
+++ b/android/sdk/buildSrc/packageName.gradle
@@ -16,7 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+task copyProguard(type: Copy){
+    if(!project.useApachePackageName){
+        inputs.file new File('proguard-rules.pro')
+        from new File('proguard-rules.pro')
+        into new File('.')
+        rename 'proguard-rules.pro', 'proguard-rules-legacy.pro'
+        filter { String line ->
+            line.replaceAll(/(org\.apache)(\.weex.*)/, { _, packageName, suffix ->
+                "com.taobao${suffix}"
+            })
+        }
+    }
+}
+
 task copyAndRenamePackage(type: Copy) {
+    dependsOn copyProguard
     if(!project.useApachePackageName) {
         inputs.dir new File('src/main/java/org/apache/weex')
         from new File('src/main/java/org/apache/weex')
@@ -34,6 +49,7 @@ task copyAndRenamePackage(type: Copy) {
 }
 
 task copyManifest(type: Copy){
+    dependsOn copyProguard
     if(!project.useApachePackageName){
         inputs.file new File('src/main/AndroidManifest.xml')
         from new File('src/main/AndroidManifest.xml')
@@ -46,25 +62,100 @@ task copyManifest(type: Copy){
     }
 }
 
-task copyProguard(type: Copy){
-    if(!project.useApachePackageName){
-        inputs.file new File('proguard-rules.pro')
-        from new File('proguard-rules.pro')
-        into new File('.')
-        rename 'proguard-rules.pro', 'proguard-rules-legacy.pro'
-        filter { String line ->
-            line.replaceAll(/(org\.apache)(\.weex.*)/, { _, packageName, suffix ->
-                "com.taobao${suffix}"
-            })
+//task(cleanCopyProguard, overwrite: true, type: Delete){
+//    delete 'proguard-rules-legacy.pro'
+//}
+
+gradle.taskGraph.beforeTask { Task task ->
+    if(task.name == 'assembleApacheRelease'){
+        throw new StopActionException('Not Supported. assembleApacheRelease is not supported, please use the following command instead.\n assembleRelease -PapachePackageName="true"')
+    }
+    else if(task.name == 'assembleLegacyRelease'){
+        throw new StopActionException('Not Supported. assembleLegacyRelease is not supported, please use the following command instead.\n assembleRelease -PapachePackageName="false"')
+    }
+}
+
+
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def jsc_dir = new File(project.buildDir, 'jsc')
+def jsc_url = project.hasProperty('jsc_url') ? new URL(project.getProperty('jsc_url').toString()) : new URL('https://www.n7shadowjoker.com/download/jsc-android-2026004.0.1.tgz')
+def aar_name = project.hasProperty('aar_name') ? project.getProperty('aar_name').toString() : 'android-jsc-intl'
+
+def jsc_file = new File(jsc_dir, jsc_url.path.split('/').last())
+def aar_file = new File(jsc_dir, "${aar_name}.aar")
+
+def downloadJSC = { URL url, File dest ->
+    if (!dest.getParentFile().exists()) {
+        dest.getParentFile().mkdirs()
+    }
+    url.withInputStream { i -> dest.withOutputStream { it << i } }
+}
+
+task download(){
+    inputs.property('url', jsc_url)
+    outputs.file(jsc_file)
+    outputs.upToDateWhen {
+        jsc_file.exists()
+    }
+    doFirst {
+        if (!jsc_file.exists()) {
+            downloadJSC(jsc_url, jsc_file)
         }
     }
 }
 
-task(cleanCopyProguard, overwrite: true, type: Delete){
-    delete 'proguard-rules-legacy.pro'
+task unzipJSC(type: Copy, dependsOn: download) {
+    dependsOn copyProguard
+    from jsc_file.name.endsWith(".aar") ? jsc_file : tarTree(jsc_file)
+    into jsc_dir
+    include "**/*${aar_name}*.aar", '**/include/*.h'
+    includeEmptyDirs false
+    eachFile {
+        if(it.name.endsWith('.aar')) {
+            it.path = it.name
+            it.name = "${aar_name}.aar"
+        }
+        else if(it.name.endsWith('.h')){
+            it.path= 'include/' + it.name
+        }
+    }
+    inputs.file(jsc_file)
+    outputs.file(aar_file)
+    outputs.upToDateWhen {
+        aar_file.exists()
+    }
 }
 
+task copyJSCHeaderToWeexCore(type: Copy, dependsOn: unzipJSC) {
+    dependsOn copyProguard
+    from new File(jsc_dir, 'include')
+    into '../../weex_core/Source/include/JSCHeaderNew/JavaScriptCore'
+    includeEmptyDirs false
+    inputs.dir(new File(jsc_dir, 'include'))
+}
+
+
 task copyOtherCppFile(type: Copy){
+    dependsOn copyJSCHeaderToWeexCore
     if(!project.useApachePackageName) {
         inputs.dir new File('../../weex_core')
         from new File('../../weex_core')
@@ -89,14 +180,22 @@ task copyAndRenameCppSourceFile(type: Copy){
     }
 }
 
-gradle.taskGraph.beforeTask { Task task ->
-    if(task.name == 'assembleApacheRelease'){
-        throw new StopActionException('Not Supported. assembleApacheRelease is not supported, please use the following command instead.\n assembleRelease -PapachePackageName="true"')
+task copyJscToJniDir(type: Copy, dependsOn: unzipJSC) {
+    def libsDir = project.android.sourceSets.main.jniLibs.srcDirs[-1]
+    from zipTree(aar_file)
+    into libsDir
+    include 'jni/**/*.so'
+    exclude '**/libweexcore.so', '**/libweexjsb.so', '**/libweexjss.so',
+            '**/libweexjssr.so', '**/libweexjst.so', '**/libc++_shared.so'
+    includeEmptyDirs false
+    eachFile {
+        def path_list = new LinkedList<>(it.relativePath.segments.toList())
+        path_list.removeAt(0)
+        it.relativePath = new RelativePath(true, path_list[0], path_list[1])
     }
-    else if(task.name == 'assembleLegacyRelease'){
-        throw new StopActionException('Not Supported. assembleLegacyRelease is not supported, please use the following command instead.\n assembleRelease -PapachePackageName="false"')
-    }
+    inputs.file(aar_file)
+    outputs.upToDateWhen {false}
 }
 
-preBuild.dependsOn copyAndRenameCppSourceFile, copyAndRenamePackage, copyManifest, copyProguard
-clean.dependsOn cleanCopyAndRenamePackage, cleanCopyManifest, cleanCopyProguard, cleanCopyOtherCppFile, cleanCopyAndRenameCppSourceFile
+preBuild.dependsOn copyJscToJniDir, copyAndRenameCppSourceFile, copyAndRenamePackage, copyManifest, copyProguard
+clean.dependsOn cleanCopyJscToJniDir, cleanCopyAndRenamePackage, cleanCopyManifest, cleanCopyProguard, cleanCopyOtherCppFile, cleanCopyAndRenameCppSourceFile

--- a/android/sdk/buildSrc/unstripped.gradle
+++ b/android/sdk/buildSrc/unstripped.gradle
@@ -51,18 +51,18 @@ def processNativeLibs = { unstripped, stripped ->
 }
 
 afterEvaluate { project ->
-    transformNativeLibsWithStripDebugSymbolForRelease.doLast {
-        processNativeLibs transformNativeLibsWithMergeJniLibsForRelease,
-                transformNativeLibsWithStripDebugSymbolForRelease
-    }
-
-    transformNativeLibsWithStripDebugSymbolForApacheRelease.doLast {
-        processNativeLibs transformNativeLibsWithMergeJniLibsForApacheRelease,
-                transformNativeLibsWithStripDebugSymbolForApacheRelease
-    }
-
-    transformNativeLibsWithStripDebugSymbolForLegacyRelease.doLast {
-        processNativeLibs transformNativeLibsWithMergeJniLibsForLegacyRelease,
-                transformNativeLibsWithStripDebugSymbolForLegacyRelease
-    }
+//    transformNativeLibsWithStripDebugSymbolForRelease.doLast {
+//        processNativeLibs transformNativeLibsWithMergeJniLibsForRelease,
+//                transformNativeLibsWithStripDebugSymbolForRelease
+//    }
+//
+//    transformNativeLibsWithStripDebugSymbolForApacheRelease.doLast {
+//        processNativeLibs transformNativeLibsWithMergeJniLibsForApacheRelease,
+//                transformNativeLibsWithStripDebugSymbolForApacheRelease
+//    }
+//
+//    transformNativeLibsWithStripDebugSymbolForLegacyRelease.doLast {
+//        processNativeLibs transformNativeLibsWithMergeJniLibsForLegacyRelease,
+//                transformNativeLibsWithStripDebugSymbolForLegacyRelease
+//    }
 }

--- a/android/sdk/src/main/AndroidManifest.xml
+++ b/android/sdk/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="org.apache.weex">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 </manifest>

--- a/weex_core/Source/android/jsengine/task/back_to_weex_core_queue.cpp
+++ b/weex_core/Source/android/jsengine/task/back_to_weex_core_queue.cpp
@@ -73,10 +73,12 @@ BackToWeexCoreQueue::IPCTask *BackToWeexCoreQueue::getTask() {
             continue;
         }
 
-        assert(!taskQueue_.empty());
-        task = taskQueue_.front();
-        taskQueue_.pop_front();
-        threadLocker.unlock();
+//        assert(!taskQueue_.empty());
+        if (!taskQueue_.empty()) {
+            task = taskQueue_.front();
+            taskQueue_.pop_front();
+            threadLocker.unlock();
+        }
     }
 
     return task;

--- a/weex_core/Source/android/jsengine/task/timer_queue.cpp
+++ b/weex_core/Source/android/jsengine/task/timer_queue.cpp
@@ -114,17 +114,19 @@ TimerTask *TimerQueue::getTask() {
             threadLocker.unlock();
             continue;
         }
-        assert(!timerQueue_.empty());
-        TimerTask *header = timerQueue_.front();
-        nextTaskWhen = header->when;
-        if (microTime() > nextTaskWhen) {
-            timerQueue_.pop_front();
-            task = header;
-        } else {
+//        assert(!timerQueue_.empty());
+        if (!timerQueue_.empty()) {
+            TimerTask *header = timerQueue_.front();
+            nextTaskWhen = header->when;
+            if (microTime() > nextTaskWhen) {
+                timerQueue_.pop_front();
+                task = header;
+            } else {
+                threadLocker.unlock();
+                continue;
+            }
             threadLocker.unlock();
-            continue;
         }
-        threadLocker.unlock();
     }
     return task;
 }

--- a/weex_core/Source/android/jsengine/task/weex_task_queue.cpp
+++ b/weex_core/Source/android/jsengine/task/weex_task_queue.cpp
@@ -68,10 +68,12 @@ WeexTask *WeexTaskQueue::getTask() {
           return nullptr;
         }
 
-        assert(!taskQueue_.empty());
-        task = taskQueue_.front();
-        taskQueue_.pop_front();
-        threadLocker.unlock();
+//        assert(!taskQueue_.empty());
+        if (!taskQueue_.empty()) {
+            task = taskQueue_.front();
+            taskQueue_.pop_front();
+            threadLocker.unlock();
+        }
     }
 
     return task;

--- a/weex_core/Source/android/jsengine/weexjsserver_version_script.txt
+++ b/weex_core/Source/android/jsengine/weexjsserver_version_script.txt
@@ -1,4 +1,4 @@
 {
-    global: serverMain;CallT3dFunc; CallGCanvasFun;ExchangeJSBridgeFunctions;ExchangePlatformBridgeFunctions;
+    global: serverMain;ExchangeJSBridgeFunctions;
     local: *;
 };

--- a/weex_core/Source/js_runtime/weex/task/back_to_weex_core_queue.cpp
+++ b/weex_core/Source/js_runtime/weex/task/back_to_weex_core_queue.cpp
@@ -74,10 +74,12 @@ BackToWeexCoreQueue::IPCTask *BackToWeexCoreQueue::getTask() {
             continue;
         }
 
-        assert(!taskQueue_.empty());
-        task = taskQueue_.front();
-        taskQueue_.pop_front();
-        threadLocker.unlock();
+//        assert(!taskQueue_.empty());
+        if (!taskQueue_.empty()) {
+            task = taskQueue_.front();
+            taskQueue_.pop_front();
+            threadLocker.unlock();
+        }
     }
 
     return task;

--- a/weex_core/Source/js_runtime/weex/task/timer_queue.cpp
+++ b/weex_core/Source/js_runtime/weex/task/timer_queue.cpp
@@ -127,17 +127,19 @@ TimerTask *TimerQueue::getTask() {
       threadLocker.unlock();
       continue;
     }
-    assert(!taskQueue_.empty());
-    TimerTask *header = timerQueue_.front();
-    nextTaskWhen = header->when;
-    if (microTime() > nextTaskWhen) {
-      timerQueue_.pop_front();
-      task = header;
-    } else {
-      threadLocker.unlock();
-      continue;
-    }
-    threadLocker.unlock();
+//    assert(!taskQueue_.empty());
+      if (!timerQueue_.empty()) {
+          TimerTask *header = timerQueue_.front();
+          nextTaskWhen = header->when;
+          if (microTime() > nextTaskWhen) {
+              timerQueue_.pop_front();
+              task = header;
+          } else {
+              threadLocker.unlock();
+              continue;
+          }
+          threadLocker.unlock();
+      }
   }
   return task;
 }

--- a/weex_core/Source/js_runtime/weex/task/weex_task_queue.cpp
+++ b/weex_core/Source/js_runtime/weex/task/weex_task_queue.cpp
@@ -69,10 +69,12 @@ WeexTask *WeexTaskQueue::getTask() {
           return nullptr;
         }
 
-        assert(!taskQueue_.empty());
-        task = taskQueue_.front();
-        taskQueue_.pop_front();
-        threadLocker.unlock();
+//        assert(!taskQueue_.empty());
+        if (!taskQueue_.empty()) {
+            task = taskQueue_.front();
+            taskQueue_.pop_front();
+            threadLocker.unlock();
+        }
     }
 
     return task;


### PR DESCRIPTION
# Weex 适配 16KB PageSize 版本
## 简介
基于 Weex 原版，适配 Android 16KB PageSize 问题。

## 主要改动点
- 升级 NDK 27，适配 16KB PageSize
- 更新 ReactNative 发布的最新 JSCore，适配 16KB PageSize
- 配套工具链升级，Gradle配置修改
- C++ 代码修改，由于升级 NDK 27，部分老代码需要做调整

## 编译环境需求
- Java 17
- NDK 27.1.12297006
- CMake 3.22.1
- Gradle 8.10.2
- APG 8.7.2

## 编译步骤
1. 首先确保环境正确，各工具的版本严格符合编译环境说明
2. 进入到工程中 android 路径下（可以直接使用 AndroidStudio 打开这个路径，这是一个标准的Android工程）
3. 执行 `./gradlew assembleRelease` 编译项目
4. 编译完成后，在 android/sdk/build/outputs/aar 目录下会生成 aar 文件。
5. 在自己的项目中使用这个 AAR 作为 Weex SDK。

## 注意事项
- 如果集成 AAR 包以后，启动闪退，可能是由于 libc++shared.so 版本不一致问题。Weex AAR 包中包含了 libc++shared.so，需要确保 App 使用相同的版本和这个相同。

## 联系方式
- 欢迎沟通交流，请加微信：Shepard-N7，麻烦写一下备注